### PR TITLE
ci: fixate python version in docs action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.12.2"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixing ci/docs failure