### PR TITLE
feat: pick up seaborn heatmap fmt towards maidr

### DIFF
--- a/example/bar/example_bar_plot.ipynb
+++ b/example/bar/example_bar_plot.ipynb
@@ -45,6 +45,7 @@
     "cut_counts = tips[\"day\"].value_counts()\n",
     "plt.figure(figsize=(10, 6))\n",
     "b_plot = plt.bar(cut_counts.index, list(cut_counts.values), color=\"skyblue\")\n",
+    "print(type(b_plot))\n",
     "plt.title(\"The Number of Tips by Day\")\n",
     "plt.xlabel(\"Day\")\n",
     "plt.ylabel(\"Count\")\n",

--- a/example/bar/example_bar_plot.ipynb
+++ b/example/bar/example_bar_plot.ipynb
@@ -45,7 +45,6 @@
     "cut_counts = tips[\"day\"].value_counts()\n",
     "plt.figure(figsize=(10, 6))\n",
     "b_plot = plt.bar(cut_counts.index, list(cut_counts.values), color=\"skyblue\")\n",
-    "print(type(b_plot))\n",
     "plt.title(\"The Number of Tips by Day\")\n",
     "plt.xlabel(\"Day\")\n",
     "plt.ylabel(\"Count\")\n",

--- a/maidr/core/plot/heatmap.py
+++ b/maidr/core/plot/heatmap.py
@@ -21,7 +21,7 @@ class HeatPlot(
 ):
     def __init__(self, ax: Axes, **kwargs) -> None:
         self._fill_label = kwargs.pop("fill_label")
-        self._fmt = kwargs.pop("fmt", ".2f")
+        self._fmt = kwargs.pop("fmt")
         super().__init__(ax, PlotType.HEAT)
 
     def render(self) -> dict:

--- a/maidr/core/plot/heatmap.py
+++ b/maidr/core/plot/heatmap.py
@@ -21,6 +21,7 @@ class HeatPlot(
 ):
     def __init__(self, ax: Axes, **kwargs) -> None:
         self._fill_label = kwargs.pop("fill_label")
+        self._fmt = kwargs.pop("fmt", ".2f")
         super().__init__(ax, PlotType.HEAT)
 
     def render(self) -> dict:
@@ -71,4 +72,4 @@ class HeatPlot(
         else:
             self._support_highlighting = False
 
-        return [list(map(float, row)) for row in array]
+        return [list(map(lambda x: float(format(x, self._fmt)), row)) for row in array]

--- a/maidr/patch/heatmap.py
+++ b/maidr/patch/heatmap.py
@@ -12,17 +12,14 @@ from maidr.core.figure_manager import FigureManager
 def heat(wrapped, _, args, kwargs) -> Axes | AxesImage:
     # Check for additional label used by MAIDR heatmap.
     fill_label = kwargs.pop("fill_label", "Fill")
-
-    _fmt = ".2f"
-    if "fmt" in kwargs:
-        _fmt = kwargs.get("fmt")
+    fmt = kwargs.get("fmt", "")
 
     # Patch `ax.imshow()` and `seaborn.heatmap`.
     plot = wrapped(*args, **kwargs)
 
     # Extract the heatmap data points for MAIDR from the plots.
     ax = FigureManager.get_axes(plot)
-    FigureManager.create_maidr(ax, PlotType.HEAT, fill_label=fill_label, fmt=_fmt)
+    FigureManager.create_maidr(ax, PlotType.HEAT, fill_label=fill_label, fmt=fmt)
 
     # Return to the caller.
     return plot

--- a/maidr/patch/heatmap.py
+++ b/maidr/patch/heatmap.py
@@ -13,12 +13,16 @@ def heat(wrapped, _, args, kwargs) -> Axes | AxesImage:
     # Check for additional label used by MAIDR heatmap.
     fill_label = kwargs.pop("fill_label", "Fill")
 
+    _fmt = ".2f"
+    if "fmt" in kwargs:
+        _fmt = kwargs.get("fmt")
+
     # Patch `ax.imshow()` and `seaborn.heatmap`.
     plot = wrapped(*args, **kwargs)
 
     # Extract the heatmap data points for MAIDR from the plots.
     ax = FigureManager.get_axes(plot)
-    FigureManager.create_maidr(ax, PlotType.HEAT, fill_label=fill_label)
+    FigureManager.create_maidr(ax, PlotType.HEAT, fill_label=fill_label, fmt=_fmt)
 
     # Return to the caller.
     return plot


### PR DESCRIPTION
<!-- Suggested PR Title: [feat/fix/refactor/perf/test/ci/docs/chore] brief description of the change -->
<!-- Please follow Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
This PR picks up the seaborn heatmap's fmt argument and applies it to the values displayed in maidr. This is done so by passing the argument fmt to the patched heatmap plot. 

closes #77 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Pull Request

## Description
<!-- Provide a brief description of the changes made in this pull request. -->

## Related Issues
<!-- Specify any related issues or tickets that this pull request addresses. -->

## Changes Made
<!-- Describe the specific changes made in this pull request. -->
1. Parsed the fmt argument from kwargs in the heatmap patch.
2. Passed the fmt argument in FigureManager's create_maidr function.
3. Stored the value of fmt, which helps to format the values to display 
## Screenshots (if applicable)
<!-- Include any relevant screenshots or images to help visualize the changes. -->
<!-- You can take a gif animation screenshot very easily without any additional installation by using this browser-based tool: -->
<!-- https://gifcap.dev -->
<img width="1366" alt="image" src="https://github.com/user-attachments/assets/4085c8e3-4533-4f39-b7f6-13c460e266ba">

## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [x] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [x] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [x] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation, if applicable.
- [x] I have added appropriate unit tests, if applicable.

## Additional Notes
<!-- Add any additional notes or comments here. -->
<!-- Template credit: This pull request template is based on Embedded Artistry {https://github.com/embeddedartistry/templates/blob/master/.github/PULL_REQUEST_TEMPLATE.md}, Clowder {https://github.com/clowder-framework/clowder/blob/develop/.github/PULL_REQUEST_TEMPLATE.md}, and TalAter {https://github.com/TalAter/open-source-templates} templates. -->
