### PR TITLE
feat: support 2-layered scatter plot

### DIFF
--- a/example/scatter/example_scatter_2_layer.py
+++ b/example/scatter/example_scatter_2_layer.py
@@ -1,0 +1,36 @@
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+import maidr
+
+
+penguins = sns.load_dataset("penguins")
+
+# Initialize the plot
+fig, ax = plt.subplots(figsize=(10, 6))
+
+# Prepare Scatter plot layer
+sns.scatterplot(data=penguins, x="flipper_length_mm", y="body_mass_g", s=100, ax=ax)
+
+# Prepare Line plot layer
+sns.regplot(
+    data=penguins,
+    x="flipper_length_mm",
+    y="body_mass_g",
+    scatter=False,
+    lowess=True,
+    line_kws={"color": "black"},
+    ax=ax
+)
+
+ax.set_title("Penguin Flipper Length vs Body Mass (Smoothed)", fontsize=16)
+ax.set_xlabel("Flipper Length (mm)", fontsize=14)
+ax.set_ylabel("Body Mass (g)", fontsize=14)
+
+# Create a Maidr instance
+maidr_plot = maidr.Maidr(fig)
+
+html_string = maidr_plot.render(html=True).get_html_string()
+
+with open("example_scatter_2_layered.html", "w") as f:
+    f.write(html_string)

--- a/example/scatter/example_scatter_2_layered.html
+++ b/example/scatter/example_scatter_2_layered.html
@@ -1,0 +1,2173 @@
+<html>
+  <head>
+    <meta charset="UTF-8"/>
+    <title>MAIDR</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/maidr/dist/maidr_style.min.css"/>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/maidr/dist/maidr.min.js"></script>
+  </head>
+  <body>
+    <div><svg xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" width="720pt" height="432pt" viewBox="0 0 720 432" version="1.1" id="f1686e4a-a52e-4990-b588-eec9470798f3">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2024-08-27T12:59:05.599085</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 432  L 720 432  L 720 0  L 0 0  z " style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 90 384.48  L 648 384.48  L 648 51.84  L 90 51.84  z " style="fill: #ffffff"/>
+   </g>
+   <g id="PathCollection_1">
+    <defs>
+     <path id="m6e7278fbef" d="M 0 5  C 1.326016 5 2.597899 4.473168 3.535534 3.535534  C 4.473168 2.597899 5 1.326016 5 0  C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534  C 2.597899 -4.473168 1.326016 -5 0 -5  C -1.326016 -5 -2.597899 -4.473168 -3.535534 -3.535534  C -4.473168 -2.597899 -5 -1.326016 -5 0  C -5 1.326016 -4.473168 2.597899 -3.535534 3.535534  C -2.597899 4.473168 -1.326016 5 0 5  z " style="stroke: #ffffff; stroke-width: 0.8"/>
+    </defs>
+    <g clip-path="url(#pfd8f27e300)">
+     <use xlink:href="#m6e7278fbef" x="192.744222" y="281.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="235.733436" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="323.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="295.918336" y="306.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="289.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="192.744222" y="291.66" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="203.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="295.918336" y="304.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="239.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="235.733436" y="318.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="184.146379" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="201.342065" y="327.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="278.72265" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="338.90755" y="226.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="227.135593" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="306.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="330.309707" y="218.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="218.53775" y="316.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="304.516179" y="243.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="132.559322" y="310.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="184.146379" y="293.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="261.526965" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="227.135593" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="184.146379" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="244.331279" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="209.939908" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="244.331279" y="327.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="115.363636" y="331.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="184.146379" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="166.950693" y="323.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="166.950693" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="252.929122" y="318.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="218.53775" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="316.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="321.711864" y="247.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="184.146379" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="192.744222" y="318.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="218.53775" y="205.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="201.342065" y="331.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="235.733436" y="335.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="321.711864" y="226.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="227.135593" y="344.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="209.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="201.342065" y="308.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="175.548536" y="346.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="306.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="278.72265" y="247.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="235.733436" y="302.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="252.929122" y="234.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="306.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="356.103236" y="255.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="244.331279" y="352.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="278.72265" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="235.733436" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="295.918336" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="192.744222" y="356.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="304.516179" y="281.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="227.135593" y="331.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="226.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="227.135593" y="293.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="287.320493" y="255.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="218.53775" y="356.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="287.320493" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="314.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="252.929122" y="251.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="339.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="338.90755" y="222.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="293.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="321.711864" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="330.309707" y="247.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="239.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="278.72265" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="218.53775" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="244.331279" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="260.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="261.526965" y="327.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="321.711864" y="201.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="244.331279" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="295.918336" y="243.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="278.72265" y="314.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="304.516179" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="261.526965" y="302.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="261.526965" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="293.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="373.298921" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="399.09245" y="234.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="227.135593" y="310.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="235.733436" y="222.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="244.331279" y="318.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="424.885978" y="234.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="321.711864" y="230.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="166.950693" y="352.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="287.320493" y="251.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="287.320493" y="283.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="381.896764" y="199.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="209.939908" y="337.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="239.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="295.918336" y="350.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="218.53775" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="347.505393" y="281.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="192.744222" y="329.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="330.309707" y="195.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="338.90755" y="274.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="278.72265" y="209.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="295.918336" y="327.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="330.309707" y="237.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="278.72265" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="321.711864" y="253.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="252.929122" y="352.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="347.505393" y="279.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="261.526965" y="314.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="261.526965" y="316.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="244.331279" y="331.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="338.90755" y="302.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="149.755008" y="306.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="373.298921" y="270.66" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="235.733436" y="339.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="347.505393" y="260.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="278.72265" y="321.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="234.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="278.72265" y="339.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="442.081664" y="260.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="316.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="330.309707" y="302.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="295.918336" y="302.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="347.505393" y="220.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="244.331279" y="308.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="278.72265" y="329.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="356.103236" y="262.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="227.135593" y="310.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="295.918336" y="239.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="295.918336" y="310.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="244.331279" y="304.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="252.929122" y="339.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="283.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="287.320493" y="344.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="227.135593" y="289.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="239.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="218.53775" y="304.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="306.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="295.918336" y="281.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="244.331279" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="364.701079" y="260.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="287.320493" y="302.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="321.711864" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="295.918336" y="289.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="252.929122" y="300.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="330.309707" y="283.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="338.90755" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="166.950693" y="323.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="330.309707" y="281.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="247.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="338.90755" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="295.918336" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="304.516179" y="279.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="227.135593" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="364.701079" y="255.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="295.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="364.701079" y="255.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="330.309707" y="318.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="192.744222" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="306.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="226.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="192.744222" y="293.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="278.72265" y="310.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="244.331279" y="352.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="295.918336" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="318.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="330.309707" y="247.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="356.103236" y="310.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="356.103236" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="278.72265" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="399.09245" y="213.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="244.331279" y="327.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="364.701079" y="234.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="244.331279" y="314.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="381.896764" y="251.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="293.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="347.505393" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="272.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="442.081664" y="192.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="287.320493" y="369.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="399.09245" y="218.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="442.081664" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="244.331279" y="289.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="321.711864" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="321.711864" y="302.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="321.711864" y="287.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="364.701079" y="222.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="270.124807" y="310.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="459.27735" y="234.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="244.331279" y="323.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="338.90755" y="287.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="347.505393" y="316.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="364.701079" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="295.918336" y="293.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="381.896764" y="255.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="244.331279" y="314.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="330.309707" y="306.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="278.72265" y="323.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="381.896764" y="255.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="373.298921" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="304.516179" y="300.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="407.690293" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="261.526965" y="289.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="313.114022" y="289.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="416.288136" y="260.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="373.298921" y="310.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="295.918336" y="279.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="442.081664" y="251.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="338.90755" y="279.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="450.679507" y="218.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="614.038521" y="117.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="442.081664" y="222.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="510.864407" y="117.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="485.070878" y="142.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="442.081664" y="213.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="450.679507" y="192.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="519.46225" y="159.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="433.483821" y="226.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="485.070878" y="163.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="476.473035" y="205.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="493.668721" y="129.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="476.473035" y="205.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="467.875193" y="104.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="442.081664" y="243.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="502.266564" y="104.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="442.081664" y="247.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="536.657935" y="66.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="433.483821" y="192.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="545.255778" y="146.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="510.864407" y="117.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="485.070878" y="176.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="467.875193" y="226.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="485.070878" y="171.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="485.070878" y="176.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="485.070878" y="167.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="493.668721" y="251.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="485.070878" y="121.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="442.081664" y="209.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="528.060092" y="129.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="545.255778" y="155.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="433.483821" y="201.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="416.288136" y="171.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="614.038521" y="87.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="528.060092" y="163.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="528.060092" y="142.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="467.875193" y="180.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="519.46225" y="155.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="424.885978" y="230.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="424.885978" y="146.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="424.885978" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="571.049307" y="117.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="442.081664" y="234.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="493.668721" y="197.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="545.255778" y="129.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="502.266564" y="184.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="442.081664" y="243.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="571.049307" y="142.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="467.875193" y="167.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="485.070878" y="150.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="442.081664" y="188.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="528.060092" y="150.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="442.081664" y="226.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="571.049307" y="176.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="502.266564" y="184.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="528.060092" y="171.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="424.885978" y="234.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="528.060092" y="176.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="424.885978" y="222.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="562.451464" y="129.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="424.885978" y="243.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="536.657935" y="150.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="476.473035" y="226.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="622.636364" y="121.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="519.46225" y="201.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="614.038521" y="117.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="476.473035" y="205.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="605.440678" y="108.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="528.060092" y="201.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="553.853621" y="129.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="493.668721" y="197.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="536.657935" y="176.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="536.657935" y="167.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="502.266564" y="159.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="493.668721" y="201.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="614.038521" y="108.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="433.483821" y="209.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="528.060092" y="92.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="485.070878" y="197.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="553.853621" y="96.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="459.27735" y="207.66" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="536.657935" y="138.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="459.27735" y="199.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="562.451464" y="146.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="459.27735" y="197.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="596.842835" y="125.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="510.864407" y="209.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="510.864407" y="150.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="459.27735" y="186.66" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="614.038521" y="129.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="510.864407" y="180.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="596.842835" y="142.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="459.27735" y="197.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="562.451464" y="121.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="476.473035" y="188.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="579.647149" y="159.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="493.668721" y="182.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="545.255778" y="186.66" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="381.896764" y="207.66" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="571.049307" y="155.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="519.46225" y="188.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="596.842835" y="125.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="485.070878" y="178.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="596.842835" y="134.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="493.668721" y="199.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="485.070878" y="134.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="442.081664" y="201.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="519.46225" y="134.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="424.885978" y="211.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="433.483821" y="134.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="493.668721" y="176.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="605.440678" y="96.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="467.875193" y="205.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="614.038521" y="134.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="502.266564" y="228.66" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="614.038521" y="104.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="502.266564" y="186.66" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="545.255778" y="92.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="476.473035" y="182.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="485.070878" y="188.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="545.255778" y="113.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="459.27735" y="159.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6e7278fbef" x="467.875193" y="142.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+    </g>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m74e5238108" d="M 0 0  L 0 3.5  " style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m74e5238108" x="98.167951" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 170 -->
+      <g transform="translate(88.624201 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531  L 1825 531  L 1825 4091  L 703 3866  L 703 4441  L 1819 4666  L 2450 4666  L 2450 531  L 3481 531  L 3481 0  L 794 0  L 794 531  z " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-37" d="M 525 4666  L 3525 4666  L 3525 4397  L 1831 0  L 1172 0  L 2766 4134  L 525 4134  L 525 4666  z " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250  Q 1547 4250 1301 3770  Q 1056 3291 1056 2328  Q 1056 1369 1301 889  Q 1547 409 2034 409  Q 2525 409 2770 889  Q 3016 1369 3016 2328  Q 3016 3291 2770 3770  Q 2525 4250 2034 4250  z M 2034 4750  Q 2819 4750 3233 4129  Q 3647 3509 3647 2328  Q 3647 1150 3233 529  Q 2819 -91 2034 -91  Q 1250 -91 836 529  Q 422 1150 422 2328  Q 422 3509 836 4129  Q 1250 4750 2034 4750  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m74e5238108" x="184.146379" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 180 -->
+      <g transform="translate(174.602629 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216  Q 1584 2216 1326 1975  Q 1069 1734 1069 1313  Q 1069 891 1326 650  Q 1584 409 2034 409  Q 2484 409 2743 651  Q 3003 894 3003 1313  Q 3003 1734 2745 1975  Q 2488 2216 2034 2216  z M 1403 2484  Q 997 2584 770 2862  Q 544 3141 544 3541  Q 544 4100 942 4425  Q 1341 4750 2034 4750  Q 2731 4750 3128 4425  Q 3525 4100 3525 3541  Q 3525 3141 3298 2862  Q 3072 2584 2669 2484  Q 3125 2378 3379 2068  Q 3634 1759 3634 1313  Q 3634 634 3220 271  Q 2806 -91 2034 -91  Q 1263 -91 848 271  Q 434 634 434 1313  Q 434 1759 690 2068  Q 947 2378 1403 2484  z M 1172 3481  Q 1172 3119 1398 2916  Q 1625 2713 2034 2713  Q 2441 2713 2670 2916  Q 2900 3119 2900 3481  Q 2900 3844 2670 4047  Q 2441 4250 2034 4250  Q 1625 4250 1398 4047  Q 1172 3844 1172 3481  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m74e5238108" x="270.124807" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 190 -->
+      <g transform="translate(260.581057 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-39" d="M 703 97  L 703 672  Q 941 559 1184 500  Q 1428 441 1663 441  Q 2288 441 2617 861  Q 2947 1281 2994 2138  Q 2813 1869 2534 1725  Q 2256 1581 1919 1581  Q 1219 1581 811 2004  Q 403 2428 403 3163  Q 403 3881 828 4315  Q 1253 4750 1959 4750  Q 2769 4750 3195 4129  Q 3622 3509 3622 2328  Q 3622 1225 3098 567  Q 2575 -91 1691 -91  Q 1453 -91 1209 -44  Q 966 3 703 97  z M 1959 2075  Q 2384 2075 2632 2365  Q 2881 2656 2881 3163  Q 2881 3666 2632 3958  Q 2384 4250 1959 4250  Q 1534 4250 1286 3958  Q 1038 3666 1038 3163  Q 1038 2656 1286 2365  Q 1534 2075 1959 2075  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m74e5238108" x="356.103236" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 200 -->
+      <g transform="translate(346.559486 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531  L 3431 531  L 3431 0  L 469 0  L 469 531  Q 828 903 1448 1529  Q 2069 2156 2228 2338  Q 2531 2678 2651 2914  Q 2772 3150 2772 3378  Q 2772 3750 2511 3984  Q 2250 4219 1831 4219  Q 1534 4219 1204 4116  Q 875 4013 500 3803  L 500 4441  Q 881 4594 1212 4672  Q 1544 4750 1819 4750  Q 2544 4750 2975 4387  Q 3406 4025 3406 3419  Q 3406 3131 3298 2873  Q 3191 2616 2906 2266  Q 2828 2175 2409 1742  Q 1991 1309 1228 531  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m74e5238108" x="442.081664" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 210 -->
+      <g transform="translate(432.537914 399.078438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m74e5238108" x="528.060092" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 220 -->
+      <g transform="translate(518.516342 399.078438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m74e5238108" x="614.038521" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 230 -->
+      <g transform="translate(604.494771 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516  Q 3050 2419 3304 2112  Q 3559 1806 3559 1356  Q 3559 666 3084 287  Q 2609 -91 1734 -91  Q 1441 -91 1130 -33  Q 819 25 488 141  L 488 750  Q 750 597 1062 519  Q 1375 441 1716 441  Q 2309 441 2620 675  Q 2931 909 2931 1356  Q 2931 1769 2642 2001  Q 2353 2234 1838 2234  L 1294 2234  L 1294 2753  L 1863 2753  Q 2328 2753 2575 2939  Q 2822 3125 2822 3475  Q 2822 3834 2567 4026  Q 2313 4219 1838 4219  Q 1578 4219 1281 4162  Q 984 4106 628 3988  L 628 4550  Q 988 4650 1302 4700  Q 1616 4750 1894 4750  Q 2613 4750 3031 4423  Q 3450 4097 3450 3541  Q 3450 3153 3228 2886  Q 3006 2619 2597 2516  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
+     <!-- Flipper Length (mm) -->
+     <g transform="translate(297.317813 415.795938) scale(0.14 -0.14)">
+      <defs>
+       <path id="DejaVuSans-46" d="M 628 4666  L 3309 4666  L 3309 4134  L 1259 4134  L 1259 2759  L 3109 2759  L 3109 2228  L 1259 2228  L 1259 0  L 628 0  L 628 4666  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863  L 1178 4863  L 1178 0  L 603 0  L 603 4863  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500  L 1178 3500  L 1178 0  L 603 0  L 603 3500  z M 603 4863  L 1178 4863  L 1178 4134  L 603 4134  L 603 4863  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525  L 1159 -1331  L 581 -1331  L 581 3500  L 1159 3500  L 1159 2969  Q 1341 3281 1617 3432  Q 1894 3584 2278 3584  Q 2916 3584 3314 3078  Q 3713 2572 3713 1747  Q 3713 922 3314 415  Q 2916 -91 2278 -91  Q 1894 -91 1617 61  Q 1341 213 1159 525  z M 3116 1747  Q 3116 2381 2855 2742  Q 2594 3103 2138 3103  Q 1681 3103 1420 2742  Q 1159 2381 1159 1747  Q 1159 1113 1420 752  Q 1681 391 2138 391  Q 2594 391 2855 752  Q 3116 1113 3116 1747  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894  L 3597 1613  L 953 1613  Q 991 1019 1311 708  Q 1631 397 2203 397  Q 2534 397 2845 478  Q 3156 559 3463 722  L 3463 178  Q 3153 47 2828 -22  Q 2503 -91 2169 -91  Q 1331 -91 842 396  Q 353 884 353 1716  Q 353 2575 817 3079  Q 1281 3584 2069 3584  Q 2775 3584 3186 3129  Q 3597 2675 3597 1894  z M 3022 2063  Q 3016 2534 2758 2815  Q 2500 3097 2075 3097  Q 1594 3097 1305 2825  Q 1016 2553 972 2059  L 3022 2063  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963  Q 2534 3019 2420 3045  Q 2306 3072 2169 3072  Q 1681 3072 1420 2755  Q 1159 2438 1159 1844  L 1159 0  L 581 0  L 581 3500  L 1159 3500  L 1159 2956  Q 1341 3275 1631 3429  Q 1922 3584 2338 3584  Q 2397 3584 2469 3576  Q 2541 3569 2628 3553  L 2631 2963  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4c" d="M 628 4666  L 1259 4666  L 1259 531  L 3531 531  L 3531 0  L 628 0  L 628 4666  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113  L 3513 0  L 2938 0  L 2938 2094  Q 2938 2591 2744 2837  Q 2550 3084 2163 3084  Q 1697 3084 1428 2787  Q 1159 2491 1159 1978  L 1159 0  L 581 0  L 581 3500  L 1159 3500  L 1159 2956  Q 1366 3272 1645 3428  Q 1925 3584 2291 3584  Q 2894 3584 3203 3211  Q 3513 2838 3513 2113  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791  Q 2906 2416 2648 2759  Q 2391 3103 1925 3103  Q 1463 3103 1205 2759  Q 947 2416 947 1791  Q 947 1169 1205 825  Q 1463 481 1925 481  Q 2391 481 2648 825  Q 2906 1169 2906 1791  z M 3481 434  Q 3481 -459 3084 -895  Q 2688 -1331 1869 -1331  Q 1566 -1331 1297 -1286  Q 1028 -1241 775 -1147  L 775 -588  Q 1028 -725 1275 -790  Q 1522 -856 1778 -856  Q 2344 -856 2625 -561  Q 2906 -266 2906 331  L 2906 616  Q 2728 306 2450 153  Q 2172 0 1784 0  Q 1141 0 747 490  Q 353 981 353 1791  Q 353 2603 747 3093  Q 1141 3584 1784 3584  Q 2172 3584 2450 3431  Q 2728 3278 2906 2969  L 2906 3500  L 3481 3500  L 3481 434  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494  L 1172 3500  L 2356 3500  L 2356 3053  L 1172 3053  L 1172 1153  Q 1172 725 1289 603  Q 1406 481 1766 481  L 2356 481  L 2356 0  L 1766 0  Q 1100 0 847 248  Q 594 497 594 1153  L 594 3053  L 172 3053  L 172 3500  L 594 3500  L 594 4494  L 1172 4494  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-68" d="M 3513 2113  L 3513 0  L 2938 0  L 2938 2094  Q 2938 2591 2744 2837  Q 2550 3084 2163 3084  Q 1697 3084 1428 2787  Q 1159 2491 1159 1978  L 1159 0  L 581 0  L 581 4863  L 1159 4863  L 1159 2956  Q 1366 3272 1645 3428  Q 1925 3584 2291 3584  Q 2894 3584 3203 3211  Q 3513 2838 3513 2113  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856  Q 1566 4138 1362 3434  Q 1159 2731 1159 2009  Q 1159 1288 1364 580  Q 1569 -128 1984 -844  L 1484 -844  Q 1016 -109 783 600  Q 550 1309 550 2009  Q 550 2706 781 3412  Q 1013 4119 1484 4856  L 1984 4856  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828  Q 3544 3216 3844 3400  Q 4144 3584 4550 3584  Q 5097 3584 5394 3201  Q 5691 2819 5691 2113  L 5691 0  L 5113 0  L 5113 2094  Q 5113 2597 4934 2840  Q 4756 3084 4391 3084  Q 3944 3084 3684 2787  Q 3425 2491 3425 1978  L 3425 0  L 2847 0  L 2847 2094  Q 2847 2600 2669 2842  Q 2491 3084 2119 3084  Q 1678 3084 1418 2786  Q 1159 2488 1159 1978  L 1159 0  L 581 0  L 581 3500  L 1159 3500  L 1159 2956  Q 1356 3278 1631 3431  Q 1906 3584 2284 3584  Q 2666 3584 2933 3390  Q 3200 3197 3328 2828  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856  L 1013 4856  Q 1481 4119 1714 3412  Q 1947 2706 1947 2009  Q 1947 1309 1714 600  Q 1481 -109 1013 -844  L 513 -844  Q 928 -128 1133 580  Q 1338 1288 1338 2009  Q 1338 2731 1133 3434  Q 928 4138 513 4856  z " transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-46"/>
+      <use xlink:href="#DejaVuSans-6c" x="57.519531"/>
+      <use xlink:href="#DejaVuSans-69" x="85.302734"/>
+      <use xlink:href="#DejaVuSans-70" x="113.085938"/>
+      <use xlink:href="#DejaVuSans-70" x="176.5625"/>
+      <use xlink:href="#DejaVuSans-65" x="240.039062"/>
+      <use xlink:href="#DejaVuSans-72" x="301.5625"/>
+      <use xlink:href="#DejaVuSans-20" x="342.675781"/>
+      <use xlink:href="#DejaVuSans-4c" x="374.462891"/>
+      <use xlink:href="#DejaVuSans-65" x="428.425781"/>
+      <use xlink:href="#DejaVuSans-6e" x="489.949219"/>
+      <use xlink:href="#DejaVuSans-67" x="553.328125"/>
+      <use xlink:href="#DejaVuSans-74" x="616.804688"/>
+      <use xlink:href="#DejaVuSans-68" x="656.013672"/>
+      <use xlink:href="#DejaVuSans-20" x="719.392578"/>
+      <use xlink:href="#DejaVuSans-28" x="751.179688"/>
+      <use xlink:href="#DejaVuSans-6d" x="790.193359"/>
+      <use xlink:href="#DejaVuSans-6d" x="887.605469"/>
+      <use xlink:href="#DejaVuSans-29" x="985.017578"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_8">
+      <defs>
+       <path id="m13d81a00a2" d="M 0 0  L -3.5 0  " style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m13d81a00a2" x="90" y="344.16" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 3000 -->
+      <g transform="translate(57.55 347.959219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m13d81a00a2" x="90" y="302.16" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 3500 -->
+      <g transform="translate(57.55 305.959219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666  L 3169 4666  L 3169 4134  L 1269 4134  L 1269 2991  Q 1406 3038 1543 3061  Q 1681 3084 1819 3084  Q 2600 3084 3056 2656  Q 3513 2228 3513 1497  Q 3513 744 3044 326  Q 2575 -91 1722 -91  Q 1428 -91 1123 -41  Q 819 9 494 109  L 494 744  Q 775 591 1075 516  Q 1375 441 1709 441  Q 2250 441 2565 725  Q 2881 1009 2881 1497  Q 2881 1984 2565 2268  Q 2250 2553 1709 2553  Q 1456 2553 1204 2497  Q 953 2441 691 2322  L 691 4666  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m13d81a00a2" x="90" y="260.16" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 4000 -->
+      <g transform="translate(57.55 263.959219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116  L 825 1625  L 2419 1625  L 2419 4116  z M 2253 4666  L 3047 4666  L 3047 1625  L 3713 1625  L 3713 1100  L 3047 1100  L 3047 0  L 2419 0  L 2419 1100  L 313 1100  L 313 1709  L 2253 4666  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m13d81a00a2" x="90" y="218.16" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 4500 -->
+      <g transform="translate(57.55 221.959219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m13d81a00a2" x="90" y="176.16" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 5000 -->
+      <g transform="translate(57.55 179.959219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m13d81a00a2" x="90" y="134.16" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 5500 -->
+      <g transform="translate(57.55 137.959219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m13d81a00a2" x="90" y="92.16" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 6000 -->
+      <g transform="translate(57.55 95.959219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584  Q 1688 2584 1439 2293  Q 1191 2003 1191 1497  Q 1191 994 1439 701  Q 1688 409 2113 409  Q 2538 409 2786 701  Q 3034 994 3034 1497  Q 3034 2003 2786 2293  Q 2538 2584 2113 2584  z M 3366 4563  L 3366 3988  Q 3128 4100 2886 4159  Q 2644 4219 2406 4219  Q 1781 4219 1451 3797  Q 1122 3375 1075 2522  Q 1259 2794 1537 2939  Q 1816 3084 2150 3084  Q 2853 3084 3261 2657  Q 3669 2231 3669 1497  Q 3669 778 3244 343  Q 2819 -91 2113 -91  Q 1303 -91 875 529  Q 447 1150 447 2328  Q 447 3434 972 4092  Q 1497 4750 2381 4750  Q 2619 4750 2861 4703  Q 3103 4656 3366 4563  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_16">
+     <!-- Body Mass (g) -->
+     <g transform="translate(50.638437 267.810781) rotate(-90) scale(0.14 -0.14)">
+      <defs>
+       <path id="DejaVuSans-42" d="M 1259 2228  L 1259 519  L 2272 519  Q 2781 519 3026 730  Q 3272 941 3272 1375  Q 3272 1813 3026 2020  Q 2781 2228 2272 2228  L 1259 2228  z M 1259 4147  L 1259 2741  L 2194 2741  Q 2656 2741 2882 2914  Q 3109 3088 3109 3444  Q 3109 3797 2882 3972  Q 2656 4147 2194 4147  L 1259 4147  z M 628 4666  L 2241 4666  Q 2963 4666 3353 4366  Q 3744 4066 3744 3513  Q 3744 3084 3544 2831  Q 3344 2578 2956 2516  Q 3422 2416 3680 2098  Q 3938 1781 3938 1306  Q 3938 681 3513 340  Q 3088 0 2303 0  L 628 0  L 628 4666  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097  Q 1497 3097 1228 2736  Q 959 2375 959 1747  Q 959 1119 1226 758  Q 1494 397 1959 397  Q 2419 397 2687 759  Q 2956 1122 2956 1747  Q 2956 2369 2687 2733  Q 2419 3097 1959 3097  z M 1959 3584  Q 2709 3584 3137 3096  Q 3566 2609 3566 1747  Q 3566 888 3137 398  Q 2709 -91 1959 -91  Q 1206 -91 779 398  Q 353 888 353 1747  Q 353 2609 779 3096  Q 1206 3584 1959 3584  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969  L 2906 4863  L 3481 4863  L 3481 0  L 2906 0  L 2906 525  Q 2725 213 2448 61  Q 2172 -91 1784 -91  Q 1150 -91 751 415  Q 353 922 353 1747  Q 353 2572 751 3078  Q 1150 3584 1784 3584  Q 2172 3584 2448 3432  Q 2725 3281 2906 2969  z M 947 1747  Q 947 1113 1208 752  Q 1469 391 1925 391  Q 2381 391 2643 752  Q 2906 1113 2906 1747  Q 2906 2381 2643 2742  Q 2381 3103 1925 3103  Q 1469 3103 1208 2742  Q 947 2381 947 1747  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325  Q 1816 -950 1584 -1140  Q 1353 -1331 966 -1331  L 506 -1331  L 506 -850  L 844 -850  Q 1081 -850 1212 -737  Q 1344 -625 1503 -206  L 1606 56  L 191 3500  L 800 3500  L 1894 763  L 2988 3500  L 3597 3500  L 2059 -325  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4d" d="M 628 4666  L 1569 4666  L 2759 1491  L 3956 4666  L 4897 4666  L 4897 0  L 4281 0  L 4281 4097  L 3078 897  L 2444 897  L 1241 4097  L 1241 0  L 628 0  L 628 4666  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759  Q 1497 1759 1228 1600  Q 959 1441 959 1056  Q 959 750 1161 570  Q 1363 391 1709 391  Q 2188 391 2477 730  Q 2766 1069 2766 1631  L 2766 1759  L 2194 1759  z M 3341 1997  L 3341 0  L 2766 0  L 2766 531  Q 2569 213 2275 61  Q 1981 -91 1556 -91  Q 1019 -91 701 211  Q 384 513 384 1019  Q 384 1609 779 1909  Q 1175 2209 1959 2209  L 2766 2209  L 2766 2266  Q 2766 2663 2505 2880  Q 2244 3097 1772 3097  Q 1472 3097 1187 3025  Q 903 2953 641 2809  L 641 3341  Q 956 3463 1253 3523  Q 1550 3584 1831 3584  Q 2591 3584 2966 3190  Q 3341 2797 3341 1997  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397  L 2834 2853  Q 2591 2978 2328 3040  Q 2066 3103 1784 3103  Q 1356 3103 1142 2972  Q 928 2841 928 2578  Q 928 2378 1081 2264  Q 1234 2150 1697 2047  L 1894 2003  Q 2506 1872 2764 1633  Q 3022 1394 3022 966  Q 3022 478 2636 193  Q 2250 -91 1575 -91  Q 1294 -91 989 -36  Q 684 19 347 128  L 347 722  Q 666 556 975 473  Q 1284 391 1588 391  Q 1994 391 2212 530  Q 2431 669 2431 922  Q 2431 1156 2273 1281  Q 2116 1406 1581 1522  L 1381 1569  Q 847 1681 609 1914  Q 372 2147 372 2553  Q 372 3047 722 3315  Q 1072 3584 1716 3584  Q 2034 3584 2315 3537  Q 2597 3491 2834 3397  z " transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-6f" x="68.603516"/>
+      <use xlink:href="#DejaVuSans-64" x="129.785156"/>
+      <use xlink:href="#DejaVuSans-79" x="193.261719"/>
+      <use xlink:href="#DejaVuSans-20" x="252.441406"/>
+      <use xlink:href="#DejaVuSans-4d" x="284.228516"/>
+      <use xlink:href="#DejaVuSans-61" x="370.507812"/>
+      <use xlink:href="#DejaVuSans-73" x="431.787109"/>
+      <use xlink:href="#DejaVuSans-73" x="483.886719"/>
+      <use xlink:href="#DejaVuSans-20" x="535.986328"/>
+      <use xlink:href="#DejaVuSans-28" x="567.773438"/>
+      <use xlink:href="#DejaVuSans-67" x="606.787109"/>
+      <use xlink:href="#DejaVuSans-29" x="670.263672"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_15">
+    <path d="M 115.363636 330.977886  L 149.755008 322.654321  L 184.146379 313.997897  L 184.146379 313.997897  L 209.939908 307.264971  L 209.939908 307.264971  L 244.331279 298.06458  L 244.331279 298.06458  L 270.124807 290.96895  L 270.124807 290.96895  L 295.918336 282.975764  L 295.918336 282.975764  L 304.516179 280.041482  L 304.516179 280.041482  L 313.114022 276.914273  L 313.114022 276.914273  L 321.711864 273.456925  L 321.711864 273.456925  L 330.309707 269.809384  L 330.309707 269.809384  L 338.90755 266.022498  L 338.90755 266.022498  L 356.103236 258.082251  L 356.103236 258.082251  L 364.701079 253.928657  L 364.701079 253.928657  L 373.298921 249.590935  L 373.298921 249.590935  L 381.896764 245.108322  L 381.896764 245.108322  L 399.09245 235.876181  L 399.09245 235.876181  L 416.288136 225.550764  L 416.288136 225.550764  L 424.885978 220.789472  L 424.885978 220.789472  L 442.081664 210.330589  L 442.081664 210.330589  L 450.679507 205.418691  L 450.679507 205.418691  L 467.875193 195.127365  L 467.875193 195.127365  L 502.266564 175.031011  L 502.266564 175.031011  L 622.636364 104.892423  L 622.636364 104.892423  " clip-path="url(#pfd8f27e300)" style="fill: none; stroke: #000000; stroke-width: 2.25; stroke-linecap: square"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 90 384.48  L 90 51.84  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 648 384.48  L 648 51.84  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 90 384.48  L 648 384.48  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 90 51.84  L 648 51.84  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_17">
+    <!-- Penguin Flipper Length vs Body Mass (Smoothed) -->
+    <g transform="translate(170.41625 45.84) scale(0.16 -0.16)">
+     <defs>
+      <path id="DejaVuSans-50" d="M 1259 4147  L 1259 2394  L 2053 2394  Q 2494 2394 2734 2622  Q 2975 2850 2975 3272  Q 2975 3691 2734 3919  Q 2494 4147 2053 4147  L 1259 4147  z M 628 4666  L 2053 4666  Q 2838 4666 3239 4311  Q 3641 3956 3641 3272  Q 3641 2581 3239 2228  Q 2838 1875 2053 1875  L 1259 1875  L 1259 0  L 628 0  L 628 4666  z " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-75" d="M 544 1381  L 544 3500  L 1119 3500  L 1119 1403  Q 1119 906 1312 657  Q 1506 409 1894 409  Q 2359 409 2629 706  Q 2900 1003 2900 1516  L 2900 3500  L 3475 3500  L 3475 0  L 2900 0  L 2900 538  Q 2691 219 2414 64  Q 2138 -91 1772 -91  Q 1169 -91 856 284  Q 544 659 544 1381  z M 1991 3584  L 1991 3584  z " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-76" d="M 191 3500  L 800 3500  L 1894 563  L 2988 3500  L 3597 3500  L 2284 0  L 1503 0  L 191 3500  z " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-53" d="M 3425 4513  L 3425 3897  Q 3066 4069 2747 4153  Q 2428 4238 2131 4238  Q 1616 4238 1336 4038  Q 1056 3838 1056 3469  Q 1056 3159 1242 3001  Q 1428 2844 1947 2747  L 2328 2669  Q 3034 2534 3370 2195  Q 3706 1856 3706 1288  Q 3706 609 3251 259  Q 2797 -91 1919 -91  Q 1588 -91 1214 -16  Q 841 59 441 206  L 441 856  Q 825 641 1194 531  Q 1563 422 1919 422  Q 2459 422 2753 634  Q 3047 847 3047 1241  Q 3047 1584 2836 1778  Q 2625 1972 2144 2069  L 1759 2144  Q 1053 2284 737 2584  Q 422 2884 422 3419  Q 422 4038 858 4394  Q 1294 4750 2059 4750  Q 2388 4750 2728 4690  Q 3069 4631 3425 4513  z " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-50"/>
+     <use xlink:href="#DejaVuSans-65" x="56.677734"/>
+     <use xlink:href="#DejaVuSans-6e" x="118.201172"/>
+     <use xlink:href="#DejaVuSans-67" x="181.580078"/>
+     <use xlink:href="#DejaVuSans-75" x="245.056641"/>
+     <use xlink:href="#DejaVuSans-69" x="308.435547"/>
+     <use xlink:href="#DejaVuSans-6e" x="336.21875"/>
+     <use xlink:href="#DejaVuSans-20" x="399.597656"/>
+     <use xlink:href="#DejaVuSans-46" x="431.384766"/>
+     <use xlink:href="#DejaVuSans-6c" x="488.904297"/>
+     <use xlink:href="#DejaVuSans-69" x="516.6875"/>
+     <use xlink:href="#DejaVuSans-70" x="544.470703"/>
+     <use xlink:href="#DejaVuSans-70" x="607.947266"/>
+     <use xlink:href="#DejaVuSans-65" x="671.423828"/>
+     <use xlink:href="#DejaVuSans-72" x="732.947266"/>
+     <use xlink:href="#DejaVuSans-20" x="774.060547"/>
+     <use xlink:href="#DejaVuSans-4c" x="805.847656"/>
+     <use xlink:href="#DejaVuSans-65" x="859.810547"/>
+     <use xlink:href="#DejaVuSans-6e" x="921.333984"/>
+     <use xlink:href="#DejaVuSans-67" x="984.712891"/>
+     <use xlink:href="#DejaVuSans-74" x="1048.189453"/>
+     <use xlink:href="#DejaVuSans-68" x="1087.398438"/>
+     <use xlink:href="#DejaVuSans-20" x="1150.777344"/>
+     <use xlink:href="#DejaVuSans-76" x="1182.564453"/>
+     <use xlink:href="#DejaVuSans-73" x="1241.744141"/>
+     <use xlink:href="#DejaVuSans-20" x="1293.84375"/>
+     <use xlink:href="#DejaVuSans-42" x="1325.630859"/>
+     <use xlink:href="#DejaVuSans-6f" x="1394.234375"/>
+     <use xlink:href="#DejaVuSans-64" x="1455.416016"/>
+     <use xlink:href="#DejaVuSans-79" x="1518.892578"/>
+     <use xlink:href="#DejaVuSans-20" x="1578.072266"/>
+     <use xlink:href="#DejaVuSans-4d" x="1609.859375"/>
+     <use xlink:href="#DejaVuSans-61" x="1696.138672"/>
+     <use xlink:href="#DejaVuSans-73" x="1757.417969"/>
+     <use xlink:href="#DejaVuSans-73" x="1809.517578"/>
+     <use xlink:href="#DejaVuSans-20" x="1861.617188"/>
+     <use xlink:href="#DejaVuSans-28" x="1893.404297"/>
+     <use xlink:href="#DejaVuSans-53" x="1932.417969"/>
+     <use xlink:href="#DejaVuSans-6d" x="1995.894531"/>
+     <use xlink:href="#DejaVuSans-6f" x="2093.306641"/>
+     <use xlink:href="#DejaVuSans-6f" x="2154.488281"/>
+     <use xlink:href="#DejaVuSans-74" x="2215.669922"/>
+     <use xlink:href="#DejaVuSans-68" x="2254.878906"/>
+     <use xlink:href="#DejaVuSans-65" x="2318.257812"/>
+     <use xlink:href="#DejaVuSans-64" x="2379.78125"/>
+     <use xlink:href="#DejaVuSans-29" x="2443.257812"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pfd8f27e300">
+   <rect x="90" y="51.84" width="558" height="332.64"/>
+  </clipPath>
+ </defs>
+</svg>
+</div>
+  </body>
+  <script>
+let maidr = {
+  "type": "point",
+  "title": "Penguin Flipper Length vs Body Mass (Smoothed)",
+  "axes": {
+    "x": {
+      "label": "Flipper Length (mm)"
+    },
+    "y": {
+      "label": "Body Mass (g)"
+    }
+  },
+  "data": [
+    {
+      "x": 172.0,
+      "y": 3156.929933241126
+    },
+    {
+      "x": 174.0,
+      "y": 3206.03064823199
+    },
+    {
+      "x": 176.0,
+      "y": 3256.019983521152
+    },
+    {
+      "x": 178.0,
+      "y": 3307.009343373205
+    },
+    {
+      "x": 178.0,
+      "y": 3307.009343373205
+    },
+    {
+      "x": 178.0,
+      "y": 3307.009343373205
+    },
+    {
+      "x": 178.0,
+      "y": 3307.009343373205
+    },
+    {
+      "x": 179.0,
+      "y": 3332.901219222504
+    },
+    {
+      "x": 180.0,
+      "y": 3359.072648905634
+    },
+    {
+      "x": 180.0,
+      "y": 3359.072648905634
+    },
+    {
+      "x": 180.0,
+      "y": 3359.072648905634
+    },
+    {
+      "x": 180.0,
+      "y": 3359.072648905634
+    },
+    {
+      "x": 180.0,
+      "y": 3359.072648905634
+    },
+    {
+      "x": 181.0,
+      "y": 3385.5360669692095
+    },
+    {
+      "x": 181.0,
+      "y": 3385.5360669692095
+    },
+    {
+      "x": 181.0,
+      "y": 3385.5360669692095
+    },
+    {
+      "x": 181.0,
+      "y": 3385.5360669692095
+    },
+    {
+      "x": 181.0,
+      "y": 3385.5360669692095
+    },
+    {
+      "x": 181.0,
+      "y": 3385.5360669692095
+    },
+    {
+      "x": 181.0,
+      "y": 3385.5360669692095
+    },
+    {
+      "x": 182.0,
+      "y": 3412.2676563226823
+    },
+    {
+      "x": 182.0,
+      "y": 3412.2676563226823
+    },
+    {
+      "x": 182.0,
+      "y": 3412.2676563226823
+    },
+    {
+      "x": 183.0,
+      "y": 3439.226539887373
+    },
+    {
+      "x": 183.0,
+      "y": 3439.226539887373
+    },
+    {
+      "x": 184.0,
+      "y": 3466.3790954631695
+    },
+    {
+      "x": 184.0,
+      "y": 3466.3790954631695
+    },
+    {
+      "x": 184.0,
+      "y": 3466.3790954631695
+    },
+    {
+      "x": 184.0,
+      "y": 3466.3790954631695
+    },
+    {
+      "x": 184.0,
+      "y": 3466.3790954631695
+    },
+    {
+      "x": 184.0,
+      "y": 3466.3790954631695
+    },
+    {
+      "x": 184.0,
+      "y": 3466.3790954631695
+    },
+    {
+      "x": 185.0,
+      "y": 3493.699322265575
+    },
+    {
+      "x": 185.0,
+      "y": 3493.699322265575
+    },
+    {
+      "x": 185.0,
+      "y": 3493.699322265575
+    },
+    {
+      "x": 185.0,
+      "y": 3493.699322265575
+    },
+    {
+      "x": 185.0,
+      "y": 3493.699322265575
+    },
+    {
+      "x": 185.0,
+      "y": 3493.699322265575
+    },
+    {
+      "x": 185.0,
+      "y": 3493.699322265575
+    },
+    {
+      "x": 185.0,
+      "y": 3493.699322265575
+    },
+    {
+      "x": 185.0,
+      "y": 3493.699322265575
+    },
+    {
+      "x": 186.0,
+      "y": 3521.1621354697477
+    },
+    {
+      "x": 186.0,
+      "y": 3521.1621354697477
+    },
+    {
+      "x": 186.0,
+      "y": 3521.1621354697477
+    },
+    {
+      "x": 186.0,
+      "y": 3521.1621354697477
+    },
+    {
+      "x": 186.0,
+      "y": 3521.1621354697477
+    },
+    {
+      "x": 186.0,
+      "y": 3521.1621354697477
+    },
+    {
+      "x": 186.0,
+      "y": 3521.1621354697477
+    },
+    {
+      "x": 187.0,
+      "y": 3548.754997974968
+    },
+    {
+      "x": 187.0,
+      "y": 3548.754997974968
+    },
+    {
+      "x": 187.0,
+      "y": 3548.754997974968
+    },
+    {
+      "x": 187.0,
+      "y": 3548.754997974968
+    },
+    {
+      "x": 187.0,
+      "y": 3548.754997974968
+    },
+    {
+      "x": 187.0,
+      "y": 3548.754997974968
+    },
+    {
+      "x": 187.0,
+      "y": 3548.754997974968
+    },
+    {
+      "x": 187.0,
+      "y": 3548.754997974968
+    },
+    {
+      "x": 187.0,
+      "y": 3548.754997974968
+    },
+    {
+      "x": 187.0,
+      "y": 3548.754997974968
+    },
+    {
+      "x": 187.0,
+      "y": 3548.754997974968
+    },
+    {
+      "x": 187.0,
+      "y": 3548.754997974968
+    },
+    {
+      "x": 187.0,
+      "y": 3548.754997974968
+    },
+    {
+      "x": 187.0,
+      "y": 3548.754997974968
+    },
+    {
+      "x": 187.0,
+      "y": 3548.754997974968
+    },
+    {
+      "x": 187.0,
+      "y": 3548.754997974968
+    },
+    {
+      "x": 188.0,
+      "y": 3576.5131019837563
+    },
+    {
+      "x": 188.0,
+      "y": 3576.5131019837563
+    },
+    {
+      "x": 188.0,
+      "y": 3576.5131019837563
+    },
+    {
+      "x": 188.0,
+      "y": 3576.5131019837563
+    },
+    {
+      "x": 188.0,
+      "y": 3576.5131019837563
+    },
+    {
+      "x": 188.0,
+      "y": 3576.5131019837563
+    },
+    {
+      "x": 189.0,
+      "y": 3604.5811216224192
+    },
+    {
+      "x": 189.0,
+      "y": 3604.5811216224192
+    },
+    {
+      "x": 189.0,
+      "y": 3604.5811216224192
+    },
+    {
+      "x": 189.0,
+      "y": 3604.5811216224192
+    },
+    {
+      "x": 189.0,
+      "y": 3604.5811216224192
+    },
+    {
+      "x": 189.0,
+      "y": 3604.5811216224192
+    },
+    {
+      "x": 189.0,
+      "y": 3604.5811216224192
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 190.0,
+      "y": 3633.226791091482
+    },
+    {
+      "x": 191.0,
+      "y": 3664.6084189597295
+    },
+    {
+      "x": 191.0,
+      "y": 3664.6084189597295
+    },
+    {
+      "x": 191.0,
+      "y": 3664.6084189597295
+    },
+    {
+      "x": 191.0,
+      "y": 3664.6084189597295
+    },
+    {
+      "x": 191.0,
+      "y": 3664.6084189597295
+    },
+    {
+      "x": 191.0,
+      "y": 3664.6084189597295
+    },
+    {
+      "x": 191.0,
+      "y": 3664.6084189597295
+    },
+    {
+      "x": 191.0,
+      "y": 3664.6084189597295
+    },
+    {
+      "x": 191.0,
+      "y": 3664.6084189597295
+    },
+    {
+      "x": 191.0,
+      "y": 3664.6084189597295
+    },
+    {
+      "x": 191.0,
+      "y": 3664.6084189597295
+    },
+    {
+      "x": 191.0,
+      "y": 3664.6084189597295
+    },
+    {
+      "x": 191.0,
+      "y": 3664.6084189597295
+    },
+    {
+      "x": 192.0,
+      "y": 3695.671955120323
+    },
+    {
+      "x": 192.0,
+      "y": 3695.671955120323
+    },
+    {
+      "x": 192.0,
+      "y": 3695.671955120323
+    },
+    {
+      "x": 192.0,
+      "y": 3695.671955120323
+    },
+    {
+      "x": 192.0,
+      "y": 3695.671955120323
+    },
+    {
+      "x": 192.0,
+      "y": 3695.671955120323
+    },
+    {
+      "x": 192.0,
+      "y": 3695.671955120323
+    },
+    {
+      "x": 193.0,
+      "y": 3728.3837595906534
+    },
+    {
+      "x": 193.0,
+      "y": 3728.3837595906534
+    },
+    {
+      "x": 193.0,
+      "y": 3728.3837595906534
+    },
+    {
+      "x": 193.0,
+      "y": 3728.3837595906534
+    },
+    {
+      "x": 193.0,
+      "y": 3728.3837595906534
+    },
+    {
+      "x": 193.0,
+      "y": 3728.3837595906534
+    },
+    {
+      "x": 193.0,
+      "y": 3728.3837595906534
+    },
+    {
+      "x": 193.0,
+      "y": 3728.3837595906534
+    },
+    {
+      "x": 193.0,
+      "y": 3728.3837595906534
+    },
+    {
+      "x": 193.0,
+      "y": 3728.3837595906534
+    },
+    {
+      "x": 193.0,
+      "y": 3728.3837595906534
+    },
+    {
+      "x": 193.0,
+      "y": 3728.3837595906534
+    },
+    {
+      "x": 193.0,
+      "y": 3728.3837595906534
+    },
+    {
+      "x": 193.0,
+      "y": 3728.3837595906534
+    },
+    {
+      "x": 193.0,
+      "y": 3728.3837595906534
+    },
+    {
+      "x": 194.0,
+      "y": 3763.3156938183038
+    },
+    {
+      "x": 194.0,
+      "y": 3763.3156938183038
+    },
+    {
+      "x": 194.0,
+      "y": 3763.3156938183038
+    },
+    {
+      "x": 194.0,
+      "y": 3763.3156938183038
+    },
+    {
+      "x": 194.0,
+      "y": 3763.3156938183038
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 195.0,
+      "y": 3800.544368636244
+    },
+    {
+      "x": 196.0,
+      "y": 3841.7032682186214
+    },
+    {
+      "x": 196.0,
+      "y": 3841.7032682186214
+    },
+    {
+      "x": 196.0,
+      "y": 3841.7032682186214
+    },
+    {
+      "x": 196.0,
+      "y": 3841.7032682186214
+    },
+    {
+      "x": 196.0,
+      "y": 3841.7032682186214
+    },
+    {
+      "x": 196.0,
+      "y": 3841.7032682186214
+    },
+    {
+      "x": 196.0,
+      "y": 3841.7032682186214
+    },
+    {
+      "x": 196.0,
+      "y": 3841.7032682186214
+    },
+    {
+      "x": 196.0,
+      "y": 3841.7032682186214
+    },
+    {
+      "x": 196.0,
+      "y": 3841.7032682186214
+    },
+    {
+      "x": 197.0,
+      "y": 3885.126381589042
+    },
+    {
+      "x": 197.0,
+      "y": 3885.126381589042
+    },
+    {
+      "x": 197.0,
+      "y": 3885.126381589042
+    },
+    {
+      "x": 197.0,
+      "y": 3885.126381589042
+    },
+    {
+      "x": 197.0,
+      "y": 3885.126381589042
+    },
+    {
+      "x": 197.0,
+      "y": 3885.126381589042
+    },
+    {
+      "x": 197.0,
+      "y": 3885.126381589042
+    },
+    {
+      "x": 197.0,
+      "y": 3885.126381589042
+    },
+    {
+      "x": 197.0,
+      "y": 3885.126381589042
+    },
+    {
+      "x": 197.0,
+      "y": 3885.126381589042
+    },
+    {
+      "x": 198.0,
+      "y": 3930.2083517566293
+    },
+    {
+      "x": 198.0,
+      "y": 3930.2083517566293
+    },
+    {
+      "x": 198.0,
+      "y": 3930.2083517566293
+    },
+    {
+      "x": 198.0,
+      "y": 3930.2083517566293
+    },
+    {
+      "x": 198.0,
+      "y": 3930.2083517566293
+    },
+    {
+      "x": 198.0,
+      "y": 3930.2083517566293
+    },
+    {
+      "x": 198.0,
+      "y": 3930.2083517566293
+    },
+    {
+      "x": 198.0,
+      "y": 3930.2083517566293
+    },
+    {
+      "x": 199.0,
+      "y": 3976.745627185396
+    },
+    {
+      "x": 199.0,
+      "y": 3976.745627185396
+    },
+    {
+      "x": 199.0,
+      "y": 3976.745627185396
+    },
+    {
+      "x": 199.0,
+      "y": 3976.745627185396
+    },
+    {
+      "x": 199.0,
+      "y": 3976.745627185396
+    },
+    {
+      "x": 199.0,
+      "y": 3976.745627185396
+    },
+    {
+      "x": 200.0,
+      "y": 4024.735104060687
+    },
+    {
+      "x": 200.0,
+      "y": 4024.735104060687
+    },
+    {
+      "x": 200.0,
+      "y": 4024.735104060687
+    },
+    {
+      "x": 200.0,
+      "y": 4024.735104060687
+    },
+    {
+      "x": 201.0,
+      "y": 4074.182660560827
+    },
+    {
+      "x": 201.0,
+      "y": 4074.182660560827
+    },
+    {
+      "x": 201.0,
+      "y": 4074.182660560827
+    },
+    {
+      "x": 201.0,
+      "y": 4074.182660560827
+    },
+    {
+      "x": 201.0,
+      "y": 4074.182660560827
+    },
+    {
+      "x": 201.0,
+      "y": 4074.182660560827
+    },
+    {
+      "x": 202.0,
+      "y": 4125.822203440831
+    },
+    {
+      "x": 202.0,
+      "y": 4125.822203440831
+    },
+    {
+      "x": 202.0,
+      "y": 4125.822203440831
+    },
+    {
+      "x": 202.0,
+      "y": 4125.822203440831
+    },
+    {
+      "x": 203.0,
+      "y": 4179.186637889652
+    },
+    {
+      "x": 203.0,
+      "y": 4179.186637889652
+    },
+    {
+      "x": 203.0,
+      "y": 4179.186637889652
+    },
+    {
+      "x": 203.0,
+      "y": 4179.186637889652
+    },
+    {
+      "x": 203.0,
+      "y": 4179.186637889652
+    },
+    {
+      "x": 205.0,
+      "y": 4289.093079766189
+    },
+    {
+      "x": 205.0,
+      "y": 4289.093079766189
+    },
+    {
+      "x": 205.0,
+      "y": 4289.093079766189
+    },
+    {
+      "x": 206.0,
+      "y": 4350.68592730852
+    },
+    {
+      "x": 207.0,
+      "y": 4412.014711268878
+    },
+    {
+      "x": 207.0,
+      "y": 4412.014711268878
+    },
+    {
+      "x": 208.0,
+      "y": 4468.696766632509
+    },
+    {
+      "x": 208.0,
+      "y": 4468.696766632509
+    },
+    {
+      "x": 208.0,
+      "y": 4468.696766632509
+    },
+    {
+      "x": 208.0,
+      "y": 4468.696766632509
+    },
+    {
+      "x": 208.0,
+      "y": 4468.696766632509
+    },
+    {
+      "x": 208.0,
+      "y": 4468.696766632509
+    },
+    {
+      "x": 208.0,
+      "y": 4468.696766632509
+    },
+    {
+      "x": 208.0,
+      "y": 4468.696766632509
+    },
+    {
+      "x": 209.0,
+      "y": 4531.068708277555
+    },
+    {
+      "x": 209.0,
+      "y": 4531.068708277555
+    },
+    {
+      "x": 209.0,
+      "y": 4531.068708277555
+    },
+    {
+      "x": 209.0,
+      "y": 4531.068708277555
+    },
+    {
+      "x": 209.0,
+      "y": 4531.068708277555
+    },
+    {
+      "x": 210.0,
+      "y": 4593.207267971189
+    },
+    {
+      "x": 210.0,
+      "y": 4593.207267971189
+    },
+    {
+      "x": 210.0,
+      "y": 4593.207267971189
+    },
+    {
+      "x": 210.0,
+      "y": 4593.207267971189
+    },
+    {
+      "x": 210.0,
+      "y": 4593.207267971189
+    },
+    {
+      "x": 210.0,
+      "y": 4593.207267971189
+    },
+    {
+      "x": 210.0,
+      "y": 4593.207267971189
+    },
+    {
+      "x": 210.0,
+      "y": 4593.207267971189
+    },
+    {
+      "x": 210.0,
+      "y": 4593.207267971189
+    },
+    {
+      "x": 210.0,
+      "y": 4593.207267971189
+    },
+    {
+      "x": 210.0,
+      "y": 4593.207267971189
+    },
+    {
+      "x": 210.0,
+      "y": 4593.207267971189
+    },
+    {
+      "x": 210.0,
+      "y": 4593.207267971189
+    },
+    {
+      "x": 210.0,
+      "y": 4593.207267971189
+    },
+    {
+      "x": 211.0,
+      "y": 4651.682251434884
+    },
+    {
+      "x": 211.0,
+      "y": 4651.682251434884
+    },
+    {
+      "x": 212.0,
+      "y": 4713.420109887513
+    },
+    {
+      "x": 212.0,
+      "y": 4713.420109887513
+    },
+    {
+      "x": 212.0,
+      "y": 4713.420109887513
+    },
+    {
+      "x": 212.0,
+      "y": 4713.420109887513
+    },
+    {
+      "x": 212.0,
+      "y": 4713.420109887513
+    },
+    {
+      "x": 212.0,
+      "y": 4713.420109887513
+    },
+    {
+      "x": 212.0,
+      "y": 4713.420109887513
+    },
+    {
+      "x": 213.0,
+      "y": 4774.198036930457
+    },
+    {
+      "x": 213.0,
+      "y": 4774.198036930457
+    },
+    {
+      "x": 213.0,
+      "y": 4774.198036930457
+    },
+    {
+      "x": 213.0,
+      "y": 4774.198036930457
+    },
+    {
+      "x": 213.0,
+      "y": 4774.198036930457
+    },
+    {
+      "x": 213.0,
+      "y": 4774.198036930457
+    },
+    {
+      "x": 214.0,
+      "y": 4834.2982977129695
+    },
+    {
+      "x": 214.0,
+      "y": 4834.2982977129695
+    },
+    {
+      "x": 214.0,
+      "y": 4834.2982977129695
+    },
+    {
+      "x": 214.0,
+      "y": 4834.2982977129695
+    },
+    {
+      "x": 214.0,
+      "y": 4834.2982977129695
+    },
+    {
+      "x": 214.0,
+      "y": 4834.2982977129695
+    },
+    {
+      "x": 215.0,
+      "y": 4894.077678569061
+    },
+    {
+      "x": 215.0,
+      "y": 4894.077678569061
+    },
+    {
+      "x": 215.0,
+      "y": 4894.077678569061
+    },
+    {
+      "x": 215.0,
+      "y": 4894.077678569061
+    },
+    {
+      "x": 215.0,
+      "y": 4894.077678569061
+    },
+    {
+      "x": 215.0,
+      "y": 4894.077678569061
+    },
+    {
+      "x": 215.0,
+      "y": 4894.077678569061
+    },
+    {
+      "x": 215.0,
+      "y": 4894.077678569061
+    },
+    {
+      "x": 215.0,
+      "y": 4894.077678569061
+    },
+    {
+      "x": 215.0,
+      "y": 4894.077678569061
+    },
+    {
+      "x": 215.0,
+      "y": 4894.077678569061
+    },
+    {
+      "x": 215.0,
+      "y": 4894.077678569061
+    },
+    {
+      "x": 216.0,
+      "y": 4953.76130028931
+    },
+    {
+      "x": 216.0,
+      "y": 4953.76130028931
+    },
+    {
+      "x": 216.0,
+      "y": 4953.76130028931
+    },
+    {
+      "x": 216.0,
+      "y": 4953.76130028931
+    },
+    {
+      "x": 216.0,
+      "y": 4953.76130028931
+    },
+    {
+      "x": 216.0,
+      "y": 4953.76130028931
+    },
+    {
+      "x": 216.0,
+      "y": 4953.76130028931
+    },
+    {
+      "x": 216.0,
+      "y": 4953.76130028931
+    },
+    {
+      "x": 217.0,
+      "y": 5013.44034279097
+    },
+    {
+      "x": 217.0,
+      "y": 5013.44034279097
+    },
+    {
+      "x": 217.0,
+      "y": 5013.44034279097
+    },
+    {
+      "x": 217.0,
+      "y": 5013.44034279097
+    },
+    {
+      "x": 217.0,
+      "y": 5013.44034279097
+    },
+    {
+      "x": 217.0,
+      "y": 5013.44034279097
+    },
+    {
+      "x": 218.0,
+      "y": 5073.157763206418
+    },
+    {
+      "x": 218.0,
+      "y": 5073.157763206418
+    },
+    {
+      "x": 218.0,
+      "y": 5073.157763206418
+    },
+    {
+      "x": 218.0,
+      "y": 5073.157763206418
+    },
+    {
+      "x": 218.0,
+      "y": 5073.157763206418
+    },
+    {
+      "x": 219.0,
+      "y": 5132.931693734983
+    },
+    {
+      "x": 219.0,
+      "y": 5132.931693734983
+    },
+    {
+      "x": 219.0,
+      "y": 5132.931693734983
+    },
+    {
+      "x": 219.0,
+      "y": 5132.931693734983
+    },
+    {
+      "x": 219.0,
+      "y": 5132.931693734983
+    },
+    {
+      "x": 220.0,
+      "y": 5192.759670944221
+    },
+    {
+      "x": 220.0,
+      "y": 5192.759670944221
+    },
+    {
+      "x": 220.0,
+      "y": 5192.759670944221
+    },
+    {
+      "x": 220.0,
+      "y": 5192.759670944221
+    },
+    {
+      "x": 220.0,
+      "y": 5192.759670944221
+    },
+    {
+      "x": 220.0,
+      "y": 5192.759670944221
+    },
+    {
+      "x": 220.0,
+      "y": 5192.759670944221
+    },
+    {
+      "x": 220.0,
+      "y": 5192.759670944221
+    },
+    {
+      "x": 221.0,
+      "y": 5252.6313739857305
+    },
+    {
+      "x": 221.0,
+      "y": 5252.6313739857305
+    },
+    {
+      "x": 221.0,
+      "y": 5252.6313739857305
+    },
+    {
+      "x": 221.0,
+      "y": 5252.6313739857305
+    },
+    {
+      "x": 221.0,
+      "y": 5252.6313739857305
+    },
+    {
+      "x": 222.0,
+      "y": 5312.530409681173
+    },
+    {
+      "x": 222.0,
+      "y": 5312.530409681173
+    },
+    {
+      "x": 222.0,
+      "y": 5312.530409681173
+    },
+    {
+      "x": 222.0,
+      "y": 5312.530409681173
+    },
+    {
+      "x": 222.0,
+      "y": 5312.530409681173
+    },
+    {
+      "x": 222.0,
+      "y": 5312.530409681173
+    },
+    {
+      "x": 223.0,
+      "y": 5372.435956244544
+    },
+    {
+      "x": 223.0,
+      "y": 5372.435956244544
+    },
+    {
+      "x": 224.0,
+      "y": 5432.318684959985
+    },
+    {
+      "x": 224.0,
+      "y": 5432.318684959985
+    },
+    {
+      "x": 224.0,
+      "y": 5432.318684959985
+    },
+    {
+      "x": 225.0,
+      "y": 5492.142085385231
+    },
+    {
+      "x": 225.0,
+      "y": 5492.142085385231
+    },
+    {
+      "x": 225.0,
+      "y": 5492.142085385231
+    },
+    {
+      "x": 225.0,
+      "y": 5492.142085385231
+    },
+    {
+      "x": 226.0,
+      "y": 5551.869879301563
+    },
+    {
+      "x": 228.0,
+      "y": 5670.942984434962
+    },
+    {
+      "x": 228.0,
+      "y": 5670.942984434962
+    },
+    {
+      "x": 228.0,
+      "y": 5670.942984434962
+    },
+    {
+      "x": 228.0,
+      "y": 5670.942984434962
+    },
+    {
+      "x": 229.0,
+      "y": 5730.258548376796
+    },
+    {
+      "x": 229.0,
+      "y": 5730.258548376796
+    },
+    {
+      "x": 230.0,
+      "y": 5789.419662889349
+    },
+    {
+      "x": 230.0,
+      "y": 5789.419662889349
+    },
+    {
+      "x": 230.0,
+      "y": 5789.419662889349
+    },
+    {
+      "x": 230.0,
+      "y": 5789.419662889349
+    },
+    {
+      "x": 230.0,
+      "y": 5789.419662889349
+    },
+    {
+      "x": 230.0,
+      "y": 5789.419662889349
+    },
+    {
+      "x": 230.0,
+      "y": 5789.419662889349
+    },
+    {
+      "x": 231.0,
+      "y": 5848.4235352040505
+    }
+  ],
+  "selector": "path[maidr='true']",
+  "id": "f1686e4a-a52e-4990-b588-eec9470798f3"
+}
+</script>
+</html>

--- a/example_scatter_2_layered.html
+++ b/example_scatter_2_layered.html
@@ -1,0 +1,790 @@
+<html>
+  <head>
+    <meta charset="UTF-8"/>
+    <title>MAIDR</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/maidr/dist/maidr_style.min.css"/>
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/maidr/dist/maidr.min.js"></script>
+  </head>
+  <body>
+    <div><svg xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" width="720pt" height="432pt" viewBox="0 0 720 432" version="1.1" id="6a5b7867-7441-4c8a-bf65-572b6a348c42">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2024-08-27T13:03:44.435663</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 432  L 720 432  L 720 0  L 0 0  z " style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 90 384.48  L 648 384.48  L 648 51.84  L 90 51.84  z " style="fill: #ffffff"/>
+   </g>
+   <g id="PathCollection_1">
+    <defs>
+     <path id="m6517506965" d="M 0 5  C 1.326016 5 2.597899 4.473168 3.535534 3.535534  C 4.473168 2.597899 5 1.326016 5 0  C 5 -1.326016 4.473168 -2.597899 3.535534 -3.535534  C 2.597899 -4.473168 1.326016 -5 0 -5  C -1.326016 -5 -2.597899 -4.473168 -3.535534 -3.535534  C -4.473168 -2.597899 -5 -1.326016 -5 0  C -5 1.326016 -4.473168 2.597899 -3.535534 3.535534  C -2.597899 4.473168 -1.326016 5 0 5  z " style="stroke: #ffffff; stroke-width: 0.8"/>
+    </defs>
+    <g clip-path="url(#p15a1ec1281)">
+     <use xlink:href="#m6517506965" x="192.744222" y="281.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="235.733436" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="323.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="295.918336" y="306.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="289.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="192.744222" y="291.66" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="203.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="295.918336" y="304.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="239.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="235.733436" y="318.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="184.146379" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="201.342065" y="327.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="278.72265" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="338.90755" y="226.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="227.135593" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="306.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="330.309707" y="218.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="218.53775" y="316.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="304.516179" y="243.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="132.559322" y="310.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="184.146379" y="293.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="261.526965" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="227.135593" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="184.146379" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="244.331279" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="209.939908" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="244.331279" y="327.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="115.363636" y="331.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="184.146379" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="166.950693" y="323.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="166.950693" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="252.929122" y="318.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="218.53775" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="316.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="321.711864" y="247.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="184.146379" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="192.744222" y="318.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="218.53775" y="205.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="201.342065" y="331.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="235.733436" y="335.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="321.711864" y="226.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="227.135593" y="344.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="209.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="201.342065" y="308.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="175.548536" y="346.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="306.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="278.72265" y="247.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="235.733436" y="302.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="252.929122" y="234.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="306.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="356.103236" y="255.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="244.331279" y="352.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="278.72265" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="235.733436" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="295.918336" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="192.744222" y="356.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="304.516179" y="281.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="227.135593" y="331.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="226.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="227.135593" y="293.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="287.320493" y="255.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="218.53775" y="356.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="287.320493" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="314.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="252.929122" y="251.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="339.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="338.90755" y="222.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="293.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="321.711864" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="330.309707" y="247.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="239.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="278.72265" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="218.53775" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="244.331279" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="260.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="261.526965" y="327.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="321.711864" y="201.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="244.331279" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="295.918336" y="243.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="278.72265" y="314.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="304.516179" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="261.526965" y="302.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="261.526965" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="293.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="373.298921" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="399.09245" y="234.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="227.135593" y="310.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="235.733436" y="222.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="244.331279" y="318.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="424.885978" y="234.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="321.711864" y="230.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="166.950693" y="352.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="287.320493" y="251.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="287.320493" y="283.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="381.896764" y="199.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="209.939908" y="337.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="239.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="295.918336" y="350.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="218.53775" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="347.505393" y="281.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="192.744222" y="329.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="330.309707" y="195.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="338.90755" y="274.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="278.72265" y="209.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="295.918336" y="327.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="330.309707" y="237.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="278.72265" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="321.711864" y="253.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="252.929122" y="352.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="347.505393" y="279.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="261.526965" y="314.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="261.526965" y="316.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="244.331279" y="331.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="338.90755" y="302.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="149.755008" y="306.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="373.298921" y="270.66" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="235.733436" y="339.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="347.505393" y="260.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="278.72265" y="321.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="234.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="278.72265" y="339.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="442.081664" y="260.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="316.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="330.309707" y="302.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="295.918336" y="302.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="347.505393" y="220.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="244.331279" y="308.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="278.72265" y="329.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="356.103236" y="262.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="227.135593" y="310.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="295.918336" y="239.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="295.918336" y="310.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="244.331279" y="304.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="252.929122" y="339.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="283.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="287.320493" y="344.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="227.135593" y="289.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="239.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="218.53775" y="304.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="306.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="295.918336" y="281.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="244.331279" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="364.701079" y="260.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="287.320493" y="302.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="321.711864" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="295.918336" y="289.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="252.929122" y="300.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="330.309707" y="283.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="338.90755" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="166.950693" y="323.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="330.309707" y="281.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="247.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="338.90755" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="295.918336" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="304.516179" y="279.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="227.135593" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="364.701079" y="255.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="295.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="364.701079" y="255.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="330.309707" y="318.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="192.744222" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="306.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="226.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="192.744222" y="293.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="278.72265" y="310.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="244.331279" y="352.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="295.918336" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="318.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="330.309707" y="247.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="356.103236" y="310.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="356.103236" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="278.72265" y="285.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="399.09245" y="213.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="244.331279" y="327.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="364.701079" y="234.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="244.331279" y="314.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="381.896764" y="251.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="293.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="347.505393" y="268.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="272.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="442.081664" y="192.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="287.320493" y="369.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="399.09245" y="218.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="442.081664" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="244.331279" y="289.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="321.711864" y="297.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="321.711864" y="302.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="321.711864" y="287.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="364.701079" y="222.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="270.124807" y="310.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="459.27735" y="234.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="244.331279" y="323.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="338.90755" y="287.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="347.505393" y="316.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="364.701079" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="295.918336" y="293.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="381.896764" y="255.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="244.331279" y="314.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="330.309707" y="306.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="278.72265" y="323.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="381.896764" y="255.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="373.298921" y="276.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="304.516179" y="300.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="407.690293" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="261.526965" y="289.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="313.114022" y="289.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="416.288136" y="260.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="373.298921" y="310.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="295.918336" y="279.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="442.081664" y="251.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="338.90755" y="279.06" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="450.679507" y="218.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="614.038521" y="117.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="442.081664" y="222.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="510.864407" y="117.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="485.070878" y="142.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="442.081664" y="213.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="450.679507" y="192.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="519.46225" y="159.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="433.483821" y="226.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="485.070878" y="163.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="476.473035" y="205.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="493.668721" y="129.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="476.473035" y="205.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="467.875193" y="104.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="442.081664" y="243.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="502.266564" y="104.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="442.081664" y="247.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="536.657935" y="66.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="433.483821" y="192.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="545.255778" y="146.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="510.864407" y="117.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="485.070878" y="176.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="467.875193" y="226.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="485.070878" y="171.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="485.070878" y="176.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="485.070878" y="167.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="493.668721" y="251.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="485.070878" y="121.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="442.081664" y="209.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="528.060092" y="129.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="545.255778" y="155.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="433.483821" y="201.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="416.288136" y="171.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="614.038521" y="87.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="528.060092" y="163.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="528.060092" y="142.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="467.875193" y="180.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="519.46225" y="155.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="424.885978" y="230.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="424.885978" y="146.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="424.885978" y="264.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="571.049307" y="117.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="442.081664" y="234.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="493.668721" y="197.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="545.255778" y="129.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="502.266564" y="184.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="442.081664" y="243.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="571.049307" y="142.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="467.875193" y="167.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="485.070878" y="150.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="442.081664" y="188.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="528.060092" y="150.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="442.081664" y="226.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="571.049307" y="176.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="502.266564" y="184.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="528.060092" y="171.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="424.885978" y="234.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="528.060092" y="176.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="424.885978" y="222.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="562.451464" y="129.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="424.885978" y="243.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="536.657935" y="150.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="476.473035" y="226.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="622.636364" y="121.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="519.46225" y="201.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="614.038521" y="117.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="476.473035" y="205.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="605.440678" y="108.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="528.060092" y="201.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="553.853621" y="129.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="493.668721" y="197.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="536.657935" y="176.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="536.657935" y="167.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="502.266564" y="159.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="493.668721" y="201.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="614.038521" y="108.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="433.483821" y="209.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="528.060092" y="92.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="485.070878" y="197.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="553.853621" y="96.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="459.27735" y="207.66" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="536.657935" y="138.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="459.27735" y="199.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="562.451464" y="146.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="459.27735" y="197.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="596.842835" y="125.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="510.864407" y="209.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="510.864407" y="150.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="459.27735" y="186.66" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="614.038521" y="129.96" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="510.864407" y="180.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="596.842835" y="142.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="459.27735" y="197.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="562.451464" y="121.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="476.473035" y="188.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="579.647149" y="159.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="493.668721" y="182.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="545.255778" y="186.66" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="381.896764" y="207.66" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="571.049307" y="155.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="519.46225" y="188.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="596.842835" y="125.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="485.070878" y="178.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="596.842835" y="134.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="493.668721" y="199.26" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="485.070878" y="134.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="442.081664" y="201.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="519.46225" y="134.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="424.885978" y="211.86" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="433.483821" y="134.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="493.668721" y="176.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="605.440678" y="96.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="467.875193" y="205.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="614.038521" y="134.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="502.266564" y="228.66" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="614.038521" y="104.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="502.266564" y="186.66" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="545.255778" y="92.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="476.473035" y="182.46" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="485.070878" y="188.76" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="545.255778" y="113.16" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="459.27735" y="159.36" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+     <use xlink:href="#m6517506965" x="467.875193" y="142.56" style="fill: #1f77b4; stroke: #ffffff; stroke-width: 0.8"/>
+    </g>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m6e2e626e50" d="M 0 0  L 0 3.5  " style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m6e2e626e50" x="98.167951" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 170 -->
+      <g transform="translate(88.624201 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-31" d="M 794 531  L 1825 531  L 1825 4091  L 703 3866  L 703 4441  L 1819 4666  L 2450 4666  L 2450 531  L 3481 531  L 3481 0  L 794 0  L 794 531  z " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-37" d="M 525 4666  L 3525 4666  L 3525 4397  L 1831 0  L 1172 0  L 2766 4134  L 525 4134  L 525 4666  z " transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250  Q 1547 4250 1301 3770  Q 1056 3291 1056 2328  Q 1056 1369 1301 889  Q 1547 409 2034 409  Q 2525 409 2770 889  Q 3016 1369 3016 2328  Q 3016 3291 2770 3770  Q 2525 4250 2034 4250  z M 2034 4750  Q 2819 4750 3233 4129  Q 3647 3509 3647 2328  Q 3647 1150 3233 529  Q 2819 -91 2034 -91  Q 1250 -91 836 529  Q 422 1150 422 2328  Q 422 3509 836 4129  Q 1250 4750 2034 4750  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-37" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m6e2e626e50" x="184.146379" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 180 -->
+      <g transform="translate(174.602629 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216  Q 1584 2216 1326 1975  Q 1069 1734 1069 1313  Q 1069 891 1326 650  Q 1584 409 2034 409  Q 2484 409 2743 651  Q 3003 894 3003 1313  Q 3003 1734 2745 1975  Q 2488 2216 2034 2216  z M 1403 2484  Q 997 2584 770 2862  Q 544 3141 544 3541  Q 544 4100 942 4425  Q 1341 4750 2034 4750  Q 2731 4750 3128 4425  Q 3525 4100 3525 3541  Q 3525 3141 3298 2862  Q 3072 2584 2669 2484  Q 3125 2378 3379 2068  Q 3634 1759 3634 1313  Q 3634 634 3220 271  Q 2806 -91 2034 -91  Q 1263 -91 848 271  Q 434 634 434 1313  Q 434 1759 690 2068  Q 947 2378 1403 2484  z M 1172 3481  Q 1172 3119 1398 2916  Q 1625 2713 2034 2713  Q 2441 2713 2670 2916  Q 2900 3119 2900 3481  Q 2900 3844 2670 4047  Q 2441 4250 2034 4250  Q 1625 4250 1398 4047  Q 1172 3844 1172 3481  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-38" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m6e2e626e50" x="270.124807" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 190 -->
+      <g transform="translate(260.581057 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-39" d="M 703 97  L 703 672  Q 941 559 1184 500  Q 1428 441 1663 441  Q 2288 441 2617 861  Q 2947 1281 2994 2138  Q 2813 1869 2534 1725  Q 2256 1581 1919 1581  Q 1219 1581 811 2004  Q 403 2428 403 3163  Q 403 3881 828 4315  Q 1253 4750 1959 4750  Q 2769 4750 3195 4129  Q 3622 3509 3622 2328  Q 3622 1225 3098 567  Q 2575 -91 1691 -91  Q 1453 -91 1209 -44  Q 966 3 703 97  z M 1959 2075  Q 2384 2075 2632 2365  Q 2881 2656 2881 3163  Q 2881 3666 2632 3958  Q 2384 4250 1959 4250  Q 1534 4250 1286 3958  Q 1038 3666 1038 3163  Q 1038 2656 1286 2365  Q 1534 2075 1959 2075  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-39" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m6e2e626e50" x="356.103236" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 200 -->
+      <g transform="translate(346.559486 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531  L 3431 531  L 3431 0  L 469 0  L 469 531  Q 828 903 1448 1529  Q 2069 2156 2228 2338  Q 2531 2678 2651 2914  Q 2772 3150 2772 3378  Q 2772 3750 2511 3984  Q 2250 4219 1831 4219  Q 1534 4219 1204 4116  Q 875 4013 500 3803  L 500 4441  Q 881 4594 1212 4672  Q 1544 4750 1819 4750  Q 2544 4750 2975 4387  Q 3406 4025 3406 3419  Q 3406 3131 3298 2873  Q 3191 2616 2906 2266  Q 2828 2175 2409 1742  Q 1991 1309 1228 531  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m6e2e626e50" x="442.081664" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 210 -->
+      <g transform="translate(432.537914 399.078438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-31" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m6e2e626e50" x="528.060092" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 220 -->
+      <g transform="translate(518.516342 399.078438) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m6e2e626e50" x="614.038521" y="384.48" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 230 -->
+      <g transform="translate(604.494771 399.078438) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516  Q 3050 2419 3304 2112  Q 3559 1806 3559 1356  Q 3559 666 3084 287  Q 2609 -91 1734 -91  Q 1441 -91 1130 -33  Q 819 25 488 141  L 488 750  Q 750 597 1062 519  Q 1375 441 1716 441  Q 2309 441 2620 675  Q 2931 909 2931 1356  Q 2931 1769 2642 2001  Q 2353 2234 1838 2234  L 1294 2234  L 1294 2753  L 1863 2753  Q 2328 2753 2575 2939  Q 2822 3125 2822 3475  Q 2822 3834 2567 4026  Q 2313 4219 1838 4219  Q 1578 4219 1281 4162  Q 984 4106 628 3988  L 628 4550  Q 988 4650 1302 4700  Q 1616 4750 1894 4750  Q 2613 4750 3031 4423  Q 3450 4097 3450 3541  Q 3450 3153 3228 2886  Q 3006 2619 2597 2516  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-33" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_8">
+     <!-- Flipper Length (mm) -->
+     <g transform="translate(297.317813 415.795938) scale(0.14 -0.14)">
+      <defs>
+       <path id="DejaVuSans-46" d="M 628 4666  L 3309 4666  L 3309 4134  L 1259 4134  L 1259 2759  L 3109 2759  L 3109 2228  L 1259 2228  L 1259 0  L 628 0  L 628 4666  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6c" d="M 603 4863  L 1178 4863  L 1178 0  L 603 0  L 603 4863  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-69" d="M 603 3500  L 1178 3500  L 1178 0  L 603 0  L 603 3500  z M 603 4863  L 1178 4863  L 1178 4134  L 603 4134  L 603 4863  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-70" d="M 1159 525  L 1159 -1331  L 581 -1331  L 581 3500  L 1159 3500  L 1159 2969  Q 1341 3281 1617 3432  Q 1894 3584 2278 3584  Q 2916 3584 3314 3078  Q 3713 2572 3713 1747  Q 3713 922 3314 415  Q 2916 -91 2278 -91  Q 1894 -91 1617 61  Q 1341 213 1159 525  z M 3116 1747  Q 3116 2381 2855 2742  Q 2594 3103 2138 3103  Q 1681 3103 1420 2742  Q 1159 2381 1159 1747  Q 1159 1113 1420 752  Q 1681 391 2138 391  Q 2594 391 2855 752  Q 3116 1113 3116 1747  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-65" d="M 3597 1894  L 3597 1613  L 953 1613  Q 991 1019 1311 708  Q 1631 397 2203 397  Q 2534 397 2845 478  Q 3156 559 3463 722  L 3463 178  Q 3153 47 2828 -22  Q 2503 -91 2169 -91  Q 1331 -91 842 396  Q 353 884 353 1716  Q 353 2575 817 3079  Q 1281 3584 2069 3584  Q 2775 3584 3186 3129  Q 3597 2675 3597 1894  z M 3022 2063  Q 3016 2534 2758 2815  Q 2500 3097 2075 3097  Q 1594 3097 1305 2825  Q 1016 2553 972 2059  L 3022 2063  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-72" d="M 2631 2963  Q 2534 3019 2420 3045  Q 2306 3072 2169 3072  Q 1681 3072 1420 2755  Q 1159 2438 1159 1844  L 1159 0  L 581 0  L 581 3500  L 1159 3500  L 1159 2956  Q 1341 3275 1631 3429  Q 1922 3584 2338 3584  Q 2397 3584 2469 3576  Q 2541 3569 2628 3553  L 2631 2963  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4c" d="M 628 4666  L 1259 4666  L 1259 531  L 3531 531  L 3531 0  L 628 0  L 628 4666  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6e" d="M 3513 2113  L 3513 0  L 2938 0  L 2938 2094  Q 2938 2591 2744 2837  Q 2550 3084 2163 3084  Q 1697 3084 1428 2787  Q 1159 2491 1159 1978  L 1159 0  L 581 0  L 581 3500  L 1159 3500  L 1159 2956  Q 1366 3272 1645 3428  Q 1925 3584 2291 3584  Q 2894 3584 3203 3211  Q 3513 2838 3513 2113  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-67" d="M 2906 1791  Q 2906 2416 2648 2759  Q 2391 3103 1925 3103  Q 1463 3103 1205 2759  Q 947 2416 947 1791  Q 947 1169 1205 825  Q 1463 481 1925 481  Q 2391 481 2648 825  Q 2906 1169 2906 1791  z M 3481 434  Q 3481 -459 3084 -895  Q 2688 -1331 1869 -1331  Q 1566 -1331 1297 -1286  Q 1028 -1241 775 -1147  L 775 -588  Q 1028 -725 1275 -790  Q 1522 -856 1778 -856  Q 2344 -856 2625 -561  Q 2906 -266 2906 331  L 2906 616  Q 2728 306 2450 153  Q 2172 0 1784 0  Q 1141 0 747 490  Q 353 981 353 1791  Q 353 2603 747 3093  Q 1141 3584 1784 3584  Q 2172 3584 2450 3431  Q 2728 3278 2906 2969  L 2906 3500  L 3481 3500  L 3481 434  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-74" d="M 1172 4494  L 1172 3500  L 2356 3500  L 2356 3053  L 1172 3053  L 1172 1153  Q 1172 725 1289 603  Q 1406 481 1766 481  L 2356 481  L 2356 0  L 1766 0  Q 1100 0 847 248  Q 594 497 594 1153  L 594 3053  L 172 3053  L 172 3500  L 594 3500  L 594 4494  L 1172 4494  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-68" d="M 3513 2113  L 3513 0  L 2938 0  L 2938 2094  Q 2938 2591 2744 2837  Q 2550 3084 2163 3084  Q 1697 3084 1428 2787  Q 1159 2491 1159 1978  L 1159 0  L 581 0  L 581 4863  L 1159 4863  L 1159 2956  Q 1366 3272 1645 3428  Q 1925 3584 2291 3584  Q 2894 3584 3203 3211  Q 3513 2838 3513 2113  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856  Q 1566 4138 1362 3434  Q 1159 2731 1159 2009  Q 1159 1288 1364 580  Q 1569 -128 1984 -844  L 1484 -844  Q 1016 -109 783 600  Q 550 1309 550 2009  Q 550 2706 781 3412  Q 1013 4119 1484 4856  L 1984 4856  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828  Q 3544 3216 3844 3400  Q 4144 3584 4550 3584  Q 5097 3584 5394 3201  Q 5691 2819 5691 2113  L 5691 0  L 5113 0  L 5113 2094  Q 5113 2597 4934 2840  Q 4756 3084 4391 3084  Q 3944 3084 3684 2787  Q 3425 2491 3425 1978  L 3425 0  L 2847 0  L 2847 2094  Q 2847 2600 2669 2842  Q 2491 3084 2119 3084  Q 1678 3084 1418 2786  Q 1159 2488 1159 1978  L 1159 0  L 581 0  L 581 3500  L 1159 3500  L 1159 2956  Q 1356 3278 1631 3431  Q 1906 3584 2284 3584  Q 2666 3584 2933 3390  Q 3200 3197 3328 2828  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856  L 1013 4856  Q 1481 4119 1714 3412  Q 1947 2706 1947 2009  Q 1947 1309 1714 600  Q 1481 -109 1013 -844  L 513 -844  Q 928 -128 1133 580  Q 1338 1288 1338 2009  Q 1338 2731 1133 3434  Q 928 4138 513 4856  z " transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-46"/>
+      <use xlink:href="#DejaVuSans-6c" x="57.519531"/>
+      <use xlink:href="#DejaVuSans-69" x="85.302734"/>
+      <use xlink:href="#DejaVuSans-70" x="113.085938"/>
+      <use xlink:href="#DejaVuSans-70" x="176.5625"/>
+      <use xlink:href="#DejaVuSans-65" x="240.039062"/>
+      <use xlink:href="#DejaVuSans-72" x="301.5625"/>
+      <use xlink:href="#DejaVuSans-20" x="342.675781"/>
+      <use xlink:href="#DejaVuSans-4c" x="374.462891"/>
+      <use xlink:href="#DejaVuSans-65" x="428.425781"/>
+      <use xlink:href="#DejaVuSans-6e" x="489.949219"/>
+      <use xlink:href="#DejaVuSans-67" x="553.328125"/>
+      <use xlink:href="#DejaVuSans-74" x="616.804688"/>
+      <use xlink:href="#DejaVuSans-68" x="656.013672"/>
+      <use xlink:href="#DejaVuSans-20" x="719.392578"/>
+      <use xlink:href="#DejaVuSans-28" x="751.179688"/>
+      <use xlink:href="#DejaVuSans-6d" x="790.193359"/>
+      <use xlink:href="#DejaVuSans-6d" x="887.605469"/>
+      <use xlink:href="#DejaVuSans-29" x="985.017578"/>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_8">
+      <defs>
+       <path id="ma7ab4eca2e" d="M 0 0  L -3.5 0  " style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#ma7ab4eca2e" x="90" y="344.16" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 3000 -->
+      <g transform="translate(57.55 347.959219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#ma7ab4eca2e" x="90" y="302.16" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 3500 -->
+      <g transform="translate(57.55 305.959219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666  L 3169 4666  L 3169 4134  L 1269 4134  L 1269 2991  Q 1406 3038 1543 3061  Q 1681 3084 1819 3084  Q 2600 3084 3056 2656  Q 3513 2228 3513 1497  Q 3513 744 3044 326  Q 2575 -91 1722 -91  Q 1428 -91 1123 -41  Q 819 9 494 109  L 494 744  Q 775 591 1075 516  Q 1375 441 1709 441  Q 2250 441 2565 725  Q 2881 1009 2881 1497  Q 2881 1984 2565 2268  Q 2250 2553 1709 2553  Q 1456 2553 1204 2497  Q 953 2441 691 2322  L 691 4666  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#ma7ab4eca2e" x="90" y="260.16" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 4000 -->
+      <g transform="translate(57.55 263.959219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116  L 825 1625  L 2419 1625  L 2419 4116  z M 2253 4666  L 3047 4666  L 3047 1625  L 3713 1625  L 3713 1100  L 3047 1100  L 3047 0  L 2419 0  L 2419 1100  L 313 1100  L 313 1709  L 2253 4666  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#ma7ab4eca2e" x="90" y="218.16" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 4500 -->
+      <g transform="translate(57.55 221.959219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#ma7ab4eca2e" x="90" y="176.16" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 5000 -->
+      <g transform="translate(57.55 179.959219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#ma7ab4eca2e" x="90" y="134.16" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 5500 -->
+      <g transform="translate(57.55 137.959219) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#ma7ab4eca2e" x="90" y="92.16" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 6000 -->
+      <g transform="translate(57.55 95.959219) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584  Q 1688 2584 1439 2293  Q 1191 2003 1191 1497  Q 1191 994 1439 701  Q 1688 409 2113 409  Q 2538 409 2786 701  Q 3034 994 3034 1497  Q 3034 2003 2786 2293  Q 2538 2584 2113 2584  z M 3366 4563  L 3366 3988  Q 3128 4100 2886 4159  Q 2644 4219 2406 4219  Q 1781 4219 1451 3797  Q 1122 3375 1075 2522  Q 1259 2794 1537 2939  Q 1816 3084 2150 3084  Q 2853 3084 3261 2657  Q 3669 2231 3669 1497  Q 3669 778 3244 343  Q 2819 -91 2113 -91  Q 1303 -91 875 529  Q 447 1150 447 2328  Q 447 3434 972 4092  Q 1497 4750 2381 4750  Q 2619 4750 2861 4703  Q 3103 4656 3366 4563  z " transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_16">
+     <!-- Body Mass (g) -->
+     <g transform="translate(50.638437 267.810781) rotate(-90) scale(0.14 -0.14)">
+      <defs>
+       <path id="DejaVuSans-42" d="M 1259 2228  L 1259 519  L 2272 519  Q 2781 519 3026 730  Q 3272 941 3272 1375  Q 3272 1813 3026 2020  Q 2781 2228 2272 2228  L 1259 2228  z M 1259 4147  L 1259 2741  L 2194 2741  Q 2656 2741 2882 2914  Q 3109 3088 3109 3444  Q 3109 3797 2882 3972  Q 2656 4147 2194 4147  L 1259 4147  z M 628 4666  L 2241 4666  Q 2963 4666 3353 4366  Q 3744 4066 3744 3513  Q 3744 3084 3544 2831  Q 3344 2578 2956 2516  Q 3422 2416 3680 2098  Q 3938 1781 3938 1306  Q 3938 681 3513 340  Q 3088 0 2303 0  L 628 0  L 628 4666  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097  Q 1497 3097 1228 2736  Q 959 2375 959 1747  Q 959 1119 1226 758  Q 1494 397 1959 397  Q 2419 397 2687 759  Q 2956 1122 2956 1747  Q 2956 2369 2687 2733  Q 2419 3097 1959 3097  z M 1959 3584  Q 2709 3584 3137 3096  Q 3566 2609 3566 1747  Q 3566 888 3137 398  Q 2709 -91 1959 -91  Q 1206 -91 779 398  Q 353 888 353 1747  Q 353 2609 779 3096  Q 1206 3584 1959 3584  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-64" d="M 2906 2969  L 2906 4863  L 3481 4863  L 3481 0  L 2906 0  L 2906 525  Q 2725 213 2448 61  Q 2172 -91 1784 -91  Q 1150 -91 751 415  Q 353 922 353 1747  Q 353 2572 751 3078  Q 1150 3584 1784 3584  Q 2172 3584 2448 3432  Q 2725 3281 2906 2969  z M 947 1747  Q 947 1113 1208 752  Q 1469 391 1925 391  Q 2381 391 2643 752  Q 2906 1113 2906 1747  Q 2906 2381 2643 2742  Q 2381 3103 1925 3103  Q 1469 3103 1208 2742  Q 947 2381 947 1747  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-79" d="M 2059 -325  Q 1816 -950 1584 -1140  Q 1353 -1331 966 -1331  L 506 -1331  L 506 -850  L 844 -850  Q 1081 -850 1212 -737  Q 1344 -625 1503 -206  L 1606 56  L 191 3500  L 800 3500  L 1894 763  L 2988 3500  L 3597 3500  L 2059 -325  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-4d" d="M 628 4666  L 1569 4666  L 2759 1491  L 3956 4666  L 4897 4666  L 4897 0  L 4281 0  L 4281 4097  L 3078 897  L 2444 897  L 1241 4097  L 1241 0  L 628 0  L 628 4666  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-61" d="M 2194 1759  Q 1497 1759 1228 1600  Q 959 1441 959 1056  Q 959 750 1161 570  Q 1363 391 1709 391  Q 2188 391 2477 730  Q 2766 1069 2766 1631  L 2766 1759  L 2194 1759  z M 3341 1997  L 3341 0  L 2766 0  L 2766 531  Q 2569 213 2275 61  Q 1981 -91 1556 -91  Q 1019 -91 701 211  Q 384 513 384 1019  Q 384 1609 779 1909  Q 1175 2209 1959 2209  L 2766 2209  L 2766 2266  Q 2766 2663 2505 2880  Q 2244 3097 1772 3097  Q 1472 3097 1187 3025  Q 903 2953 641 2809  L 641 3341  Q 956 3463 1253 3523  Q 1550 3584 1831 3584  Q 2591 3584 2966 3190  Q 3341 2797 3341 1997  z " transform="scale(0.015625)"/>
+       <path id="DejaVuSans-73" d="M 2834 3397  L 2834 2853  Q 2591 2978 2328 3040  Q 2066 3103 1784 3103  Q 1356 3103 1142 2972  Q 928 2841 928 2578  Q 928 2378 1081 2264  Q 1234 2150 1697 2047  L 1894 2003  Q 2506 1872 2764 1633  Q 3022 1394 3022 966  Q 3022 478 2636 193  Q 2250 -91 1575 -91  Q 1294 -91 989 -36  Q 684 19 347 128  L 347 722  Q 666 556 975 473  Q 1284 391 1588 391  Q 1994 391 2212 530  Q 2431 669 2431 922  Q 2431 1156 2273 1281  Q 2116 1406 1581 1522  L 1381 1569  Q 847 1681 609 1914  Q 372 2147 372 2553  Q 372 3047 722 3315  Q 1072 3584 1716 3584  Q 2034 3584 2315 3537  Q 2597 3491 2834 3397  z " transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-42"/>
+      <use xlink:href="#DejaVuSans-6f" x="68.603516"/>
+      <use xlink:href="#DejaVuSans-64" x="129.785156"/>
+      <use xlink:href="#DejaVuSans-79" x="193.261719"/>
+      <use xlink:href="#DejaVuSans-20" x="252.441406"/>
+      <use xlink:href="#DejaVuSans-4d" x="284.228516"/>
+      <use xlink:href="#DejaVuSans-61" x="370.507812"/>
+      <use xlink:href="#DejaVuSans-73" x="431.787109"/>
+      <use xlink:href="#DejaVuSans-73" x="483.886719"/>
+      <use xlink:href="#DejaVuSans-20" x="535.986328"/>
+      <use xlink:href="#DejaVuSans-28" x="567.773438"/>
+      <use xlink:href="#DejaVuSans-67" x="606.787109"/>
+      <use xlink:href="#DejaVuSans-29" x="670.263672"/>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_15">
+    <path d="M 115.363636 330.977886  L 149.755008 322.654321  L 184.146379 313.997897  L 184.146379 313.997897  L 209.939908 307.264971  L 209.939908 307.264971  L 244.331279 298.06458  L 244.331279 298.06458  L 270.124807 290.96895  L 270.124807 290.96895  L 295.918336 282.975764  L 295.918336 282.975764  L 304.516179 280.041482  L 304.516179 280.041482  L 313.114022 276.914273  L 313.114022 276.914273  L 321.711864 273.456925  L 321.711864 273.456925  L 330.309707 269.809384  L 330.309707 269.809384  L 338.90755 266.022498  L 338.90755 266.022498  L 356.103236 258.082251  L 356.103236 258.082251  L 364.701079 253.928657  L 364.701079 253.928657  L 373.298921 249.590935  L 373.298921 249.590935  L 381.896764 245.108322  L 381.896764 245.108322  L 399.09245 235.876181  L 399.09245 235.876181  L 416.288136 225.550764  L 416.288136 225.550764  L 424.885978 220.789472  L 424.885978 220.789472  L 442.081664 210.330589  L 442.081664 210.330589  L 450.679507 205.418691  L 450.679507 205.418691  L 467.875193 195.127365  L 467.875193 195.127365  L 502.266564 175.031011  L 502.266564 175.031011  L 622.636364 104.892423  L 622.636364 104.892423  " clip-path="url(#p15a1ec1281)" style="fill: none; stroke: #000000; stroke-width: 2.25; stroke-linecap: square"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 90 384.48  L 90 51.84  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 648 384.48  L 648 51.84  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 90 384.48  L 648 384.48  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 90 51.84  L 648 51.84  " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_17">
+    <!-- Penguin Flipper Length vs Body Mass (Smoothed) -->
+    <g transform="translate(170.41625 45.84) scale(0.16 -0.16)">
+     <defs>
+      <path id="DejaVuSans-50" d="M 1259 4147  L 1259 2394  L 2053 2394  Q 2494 2394 2734 2622  Q 2975 2850 2975 3272  Q 2975 3691 2734 3919  Q 2494 4147 2053 4147  L 1259 4147  z M 628 4666  L 2053 4666  Q 2838 4666 3239 4311  Q 3641 3956 3641 3272  Q 3641 2581 3239 2228  Q 2838 1875 2053 1875  L 1259 1875  L 1259 0  L 628 0  L 628 4666  z " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-75" d="M 544 1381  L 544 3500  L 1119 3500  L 1119 1403  Q 1119 906 1312 657  Q 1506 409 1894 409  Q 2359 409 2629 706  Q 2900 1003 2900 1516  L 2900 3500  L 3475 3500  L 3475 0  L 2900 0  L 2900 538  Q 2691 219 2414 64  Q 2138 -91 1772 -91  Q 1169 -91 856 284  Q 544 659 544 1381  z M 1991 3584  L 1991 3584  z " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-76" d="M 191 3500  L 800 3500  L 1894 563  L 2988 3500  L 3597 3500  L 2284 0  L 1503 0  L 191 3500  z " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-53" d="M 3425 4513  L 3425 3897  Q 3066 4069 2747 4153  Q 2428 4238 2131 4238  Q 1616 4238 1336 4038  Q 1056 3838 1056 3469  Q 1056 3159 1242 3001  Q 1428 2844 1947 2747  L 2328 2669  Q 3034 2534 3370 2195  Q 3706 1856 3706 1288  Q 3706 609 3251 259  Q 2797 -91 1919 -91  Q 1588 -91 1214 -16  Q 841 59 441 206  L 441 856  Q 825 641 1194 531  Q 1563 422 1919 422  Q 2459 422 2753 634  Q 3047 847 3047 1241  Q 3047 1584 2836 1778  Q 2625 1972 2144 2069  L 1759 2144  Q 1053 2284 737 2584  Q 422 2884 422 3419  Q 422 4038 858 4394  Q 1294 4750 2059 4750  Q 2388 4750 2728 4690  Q 3069 4631 3425 4513  z " transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-50"/>
+     <use xlink:href="#DejaVuSans-65" x="56.677734"/>
+     <use xlink:href="#DejaVuSans-6e" x="118.201172"/>
+     <use xlink:href="#DejaVuSans-67" x="181.580078"/>
+     <use xlink:href="#DejaVuSans-75" x="245.056641"/>
+     <use xlink:href="#DejaVuSans-69" x="308.435547"/>
+     <use xlink:href="#DejaVuSans-6e" x="336.21875"/>
+     <use xlink:href="#DejaVuSans-20" x="399.597656"/>
+     <use xlink:href="#DejaVuSans-46" x="431.384766"/>
+     <use xlink:href="#DejaVuSans-6c" x="488.904297"/>
+     <use xlink:href="#DejaVuSans-69" x="516.6875"/>
+     <use xlink:href="#DejaVuSans-70" x="544.470703"/>
+     <use xlink:href="#DejaVuSans-70" x="607.947266"/>
+     <use xlink:href="#DejaVuSans-65" x="671.423828"/>
+     <use xlink:href="#DejaVuSans-72" x="732.947266"/>
+     <use xlink:href="#DejaVuSans-20" x="774.060547"/>
+     <use xlink:href="#DejaVuSans-4c" x="805.847656"/>
+     <use xlink:href="#DejaVuSans-65" x="859.810547"/>
+     <use xlink:href="#DejaVuSans-6e" x="921.333984"/>
+     <use xlink:href="#DejaVuSans-67" x="984.712891"/>
+     <use xlink:href="#DejaVuSans-74" x="1048.189453"/>
+     <use xlink:href="#DejaVuSans-68" x="1087.398438"/>
+     <use xlink:href="#DejaVuSans-20" x="1150.777344"/>
+     <use xlink:href="#DejaVuSans-76" x="1182.564453"/>
+     <use xlink:href="#DejaVuSans-73" x="1241.744141"/>
+     <use xlink:href="#DejaVuSans-20" x="1293.84375"/>
+     <use xlink:href="#DejaVuSans-42" x="1325.630859"/>
+     <use xlink:href="#DejaVuSans-6f" x="1394.234375"/>
+     <use xlink:href="#DejaVuSans-64" x="1455.416016"/>
+     <use xlink:href="#DejaVuSans-79" x="1518.892578"/>
+     <use xlink:href="#DejaVuSans-20" x="1578.072266"/>
+     <use xlink:href="#DejaVuSans-4d" x="1609.859375"/>
+     <use xlink:href="#DejaVuSans-61" x="1696.138672"/>
+     <use xlink:href="#DejaVuSans-73" x="1757.417969"/>
+     <use xlink:href="#DejaVuSans-73" x="1809.517578"/>
+     <use xlink:href="#DejaVuSans-20" x="1861.617188"/>
+     <use xlink:href="#DejaVuSans-28" x="1893.404297"/>
+     <use xlink:href="#DejaVuSans-53" x="1932.417969"/>
+     <use xlink:href="#DejaVuSans-6d" x="1995.894531"/>
+     <use xlink:href="#DejaVuSans-6f" x="2093.306641"/>
+     <use xlink:href="#DejaVuSans-6f" x="2154.488281"/>
+     <use xlink:href="#DejaVuSans-74" x="2215.669922"/>
+     <use xlink:href="#DejaVuSans-68" x="2254.878906"/>
+     <use xlink:href="#DejaVuSans-65" x="2318.257812"/>
+     <use xlink:href="#DejaVuSans-64" x="2379.78125"/>
+     <use xlink:href="#DejaVuSans-29" x="2443.257812"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p15a1ec1281">
+   <rect x="90" y="51.84" width="558" height="332.64"/>
+  </clipPath>
+ </defs>
+</svg>
+</div>
+  </body>
+  <script>
+let maidr = []
+</script>
+</html>

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -51,9 +51,9 @@ class Maidr:
         """Return the list of plots extracted from the ``fig``."""
         return self._plots
 
-    def render(self) -> Tag:
+    def render(self, html: bool = False) -> Tag:
         """Return the maidr plot inside an iframe."""
-        return self._create_html_tag()
+        return self._create_html_tag(html)
 
     def save_html(
         self, file: str, *, lib_dir: str | None = "lib", include_version: bool = True
@@ -93,7 +93,7 @@ class Maidr:
         del self._plots
         del self._fig
 
-    def _create_html_tag(self) -> Tag:
+    def _create_html_tag(self, html: bool = False) -> Tag:
         """Create the MAIDR HTML using HTML tags."""
         tagged_elements = [element for plot in self._plots for element in plot.elements]
         with HighlightContextManager.set_maidr_elements(tagged_elements):
@@ -101,7 +101,7 @@ class Maidr:
         maidr = f"\nlet maidr = {json.dumps(self._flatten_maidr(), indent=2)}\n"
 
         # Inject plot's svg and MAIDR structure into html tag.
-        return Maidr._inject_plot(svg, maidr)
+        return Maidr._inject_plot(svg, maidr, html)
 
     def _create_html_doc(self) -> HTMLDocument:
         """Create an HTML document from Tag objects."""
@@ -149,7 +149,7 @@ class Maidr:
         return str(uuid.uuid4())
 
     @staticmethod
-    def _inject_plot(plot: HTML, maidr: str) -> Tag:
+    def _inject_plot(plot: HTML, maidr: str, html: bool = False) -> Tag:
         """Embed the plot and associated MAIDR scripts into the HTML structure."""
         base_html = tags.html(
             tags.head(
@@ -169,7 +169,8 @@ class Maidr:
             ),
             tags.script(maidr),
         )
-
+        if html:
+            return base_html
         # Embed the rendering into an iFrame for proper working of JS library.
         base_html = tags.iframe(
             srcdoc=str(base_html.get_html_string()),

--- a/poetry.lock
+++ b/poetry.lock
@@ -2252,8 +2252,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.22.4", markers = "python_version < \"3.11\""},
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -2320,6 +2320,24 @@ files = [
     {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
     {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
 ]
+
+[[package]]
+name = "patsy"
+version = "0.5.6"
+description = "A Python package for describing statistical models and for building design matrices."
+optional = false
+python-versions = "*"
+files = [
+    {file = "patsy-0.5.6-py2.py3-none-any.whl", hash = "sha256:19056886fd8fa71863fa32f0eb090267f21fb74be00f19f5c70b2e9d76c883c6"},
+    {file = "patsy-0.5.6.tar.gz", hash = "sha256:95c6d47a7222535f84bff7f63d7303f2e297747a598db89cf5c67f0c0c7d2cdb"},
+]
+
+[package.dependencies]
+numpy = ">=1.4"
+six = "*"
+
+[package.extras]
+test = ["pytest", "pytest-cov", "scipy"]
 
 [[package]]
 name = "pexpect"
@@ -3398,6 +3416,48 @@ files = [
 ]
 
 [[package]]
+name = "scipy"
+version = "1.13.1"
+description = "Fundamental algorithms for scientific computing in Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "scipy-1.13.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:20335853b85e9a49ff7572ab453794298bcf0354d8068c5f6775a0eabf350aca"},
+    {file = "scipy-1.13.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:d605e9c23906d1994f55ace80e0125c587f96c020037ea6aa98d01b4bd2e222f"},
+    {file = "scipy-1.13.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cfa31f1def5c819b19ecc3a8b52d28ffdcc7ed52bb20c9a7589669dd3c250989"},
+    {file = "scipy-1.13.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f26264b282b9da0952a024ae34710c2aff7d27480ee91a2e82b7b7073c24722f"},
+    {file = "scipy-1.13.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:eccfa1906eacc02de42d70ef4aecea45415f5be17e72b61bafcfd329bdc52e94"},
+    {file = "scipy-1.13.1-cp310-cp310-win_amd64.whl", hash = "sha256:2831f0dc9c5ea9edd6e51e6e769b655f08ec6db6e2e10f86ef39bd32eb11da54"},
+    {file = "scipy-1.13.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:27e52b09c0d3a1d5b63e1105f24177e544a222b43611aaf5bc44d4a0979e32f9"},
+    {file = "scipy-1.13.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:54f430b00f0133e2224c3ba42b805bfd0086fe488835effa33fa291561932326"},
+    {file = "scipy-1.13.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e89369d27f9e7b0884ae559a3a956e77c02114cc60a6058b4e5011572eea9299"},
+    {file = "scipy-1.13.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a78b4b3345f1b6f68a763c6e25c0c9a23a9fd0f39f5f3d200efe8feda560a5fa"},
+    {file = "scipy-1.13.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:45484bee6d65633752c490404513b9ef02475b4284c4cfab0ef946def50b3f59"},
+    {file = "scipy-1.13.1-cp311-cp311-win_amd64.whl", hash = "sha256:5713f62f781eebd8d597eb3f88b8bf9274e79eeabf63afb4a737abc6c84ad37b"},
+    {file = "scipy-1.13.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5d72782f39716b2b3509cd7c33cdc08c96f2f4d2b06d51e52fb45a19ca0c86a1"},
+    {file = "scipy-1.13.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:017367484ce5498445aade74b1d5ab377acdc65e27095155e448c88497755a5d"},
+    {file = "scipy-1.13.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:949ae67db5fa78a86e8fa644b9a6b07252f449dcf74247108c50e1d20d2b4627"},
+    {file = "scipy-1.13.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de3ade0e53bc1f21358aa74ff4830235d716211d7d077e340c7349bc3542e884"},
+    {file = "scipy-1.13.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2ac65fb503dad64218c228e2dc2d0a0193f7904747db43014645ae139c8fad16"},
+    {file = "scipy-1.13.1-cp312-cp312-win_amd64.whl", hash = "sha256:cdd7dacfb95fea358916410ec61bbc20440f7860333aee6d882bb8046264e949"},
+    {file = "scipy-1.13.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:436bbb42a94a8aeef855d755ce5a465479c721e9d684de76bf61a62e7c2b81d5"},
+    {file = "scipy-1.13.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:8335549ebbca860c52bf3d02f80784e91a004b71b059e3eea9678ba994796a24"},
+    {file = "scipy-1.13.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d533654b7d221a6a97304ab63c41c96473ff04459e404b83275b60aa8f4b7004"},
+    {file = "scipy-1.13.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:637e98dcf185ba7f8e663e122ebf908c4702420477ae52a04f9908707456ba4d"},
+    {file = "scipy-1.13.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a014c2b3697bde71724244f63de2476925596c24285c7a637364761f8710891c"},
+    {file = "scipy-1.13.1-cp39-cp39-win_amd64.whl", hash = "sha256:392e4ec766654852c25ebad4f64e4e584cf19820b980bc04960bca0b0cd6eaa2"},
+    {file = "scipy-1.13.1.tar.gz", hash = "sha256:095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c"},
+]
+
+[package.dependencies]
+numpy = ">=1.22.4,<2.3"
+
+[package.extras]
+dev = ["cython-lint (>=0.12.2)", "doit (>=0.36.0)", "mypy", "pycodestyle", "pydevtool", "rich-click", "ruff", "types-psutil", "typing_extensions"]
+doc = ["jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.12.0)", "jupytext", "matplotlib (>=3.5)", "myst-nb", "numpydoc", "pooch", "pydata-sphinx-theme (>=0.15.2)", "sphinx (>=5.0.0)", "sphinx-design (>=0.4.0)"]
+test = ["array-api-strict", "asv", "gmpy2", "hypothesis (>=6.30)", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
+
+[[package]]
 name = "seaborn"
 version = "0.13.2"
 description = "Statistical data visualization"
@@ -3561,6 +3621,51 @@ pure-eval = "*"
 
 [package.extras]
 tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
+
+[[package]]
+name = "statsmodels"
+version = "0.14.2"
+description = "Statistical computations and models for Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "statsmodels-0.14.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df5d6f95c46f0341da6c79ee7617e025bf2b371e190a8e60af1ae9cabbdb7a97"},
+    {file = "statsmodels-0.14.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a87ef21fadb445b650f327340dde703f13aec1540f3d497afb66324499dea97a"},
+    {file = "statsmodels-0.14.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5827a12e3ede2b98a784476d61d6bec43011fedb64aa815f2098e0573bece257"},
+    {file = "statsmodels-0.14.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:10f2b7611a61adb7d596a6d239abdf1a4d5492b931b00d5ed23d32844d40e48e"},
+    {file = "statsmodels-0.14.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c254c66142f1167b4c7d031cf8db55294cc62ff3280e090fc45bd10a7f5fd029"},
+    {file = "statsmodels-0.14.2-cp310-cp310-win_amd64.whl", hash = "sha256:0e46e9d59293c1af4cc1f4e5248f17e7e7bc596bfce44d327c789ac27f09111b"},
+    {file = "statsmodels-0.14.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:50fcb633987779e795142f51ba49fb27648d46e8a1382b32ebe8e503aaabaa9e"},
+    {file = "statsmodels-0.14.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:876794068abfaeed41df71b7887000031ecf44fbfa6b50d53ccb12ebb4ab747a"},
+    {file = "statsmodels-0.14.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a91f6c4943de13e3ce2e20ee3b5d26d02bd42300616a421becd53756f5deb37"},
+    {file = "statsmodels-0.14.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4864a1c4615c5ea5f2e3b078a75bdedc90dd9da210a37e0738e064b419eccee2"},
+    {file = "statsmodels-0.14.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:afbd92410e0df06f3d8c4e7c0e2e71f63f4969531f280fb66059e2ecdb6e0415"},
+    {file = "statsmodels-0.14.2-cp311-cp311-win_amd64.whl", hash = "sha256:8e004cfad0e46ce73fe3f3812010c746f0d4cfd48e307b45c14e9e360f3d2510"},
+    {file = "statsmodels-0.14.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:eb0ba1ad3627705f5ae20af6b2982f500546d43892543b36c7bca3e2f87105e7"},
+    {file = "statsmodels-0.14.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:90fd2f0110b73fc3fa5a2f21c3ca99b0e22285cccf38e56b5b8fd8ce28791b0f"},
+    {file = "statsmodels-0.14.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac780ad9ff552773798829a0b9c46820b0faa10e6454891f5e49a845123758ab"},
+    {file = "statsmodels-0.14.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:55d1742778400ae67acb04b50a2c7f5804182f8a874bd09ca397d69ed159a751"},
+    {file = "statsmodels-0.14.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:f870d14a587ea58a3b596aa994c2ed889cc051f9e450e887d2c83656fc6a64bf"},
+    {file = "statsmodels-0.14.2-cp312-cp312-win_amd64.whl", hash = "sha256:f450fcbae214aae66bd9d2b9af48e0f8ba1cb0e8596c6ebb34e6e3f0fec6542c"},
+    {file = "statsmodels-0.14.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:201c3d00929c4a67cda1fe05b098c8dcf1b1eeefa88e80a8f963a844801ed59f"},
+    {file = "statsmodels-0.14.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9edefa4ce08e40bc1d67d2f79bc686ee5e238e801312b5a029ee7786448c389a"},
+    {file = "statsmodels-0.14.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c78a7601fdae1aa32104c5ebff2e0b72c26f33e870e2f94ab1bcfd927ece9b"},
+    {file = "statsmodels-0.14.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f36494df7c03d63168fccee5038a62f469469ed6a4dd6eaeb9338abedcd0d5f5"},
+    {file = "statsmodels-0.14.2-cp39-cp39-win_amd64.whl", hash = "sha256:8875823bdd41806dc853333cc4e1b7ef9481bad2380a999e66ea42382cf2178d"},
+    {file = "statsmodels-0.14.2.tar.gz", hash = "sha256:890550147ad3a81cda24f0ba1a5c4021adc1601080bd00e191ae7cd6feecd6ad"},
+]
+
+[package.dependencies]
+numpy = ">=1.22.3"
+packaging = ">=21.3"
+pandas = ">=1.4,<2.1.0 || >2.1.0"
+patsy = ">=0.5.6"
+scipy = ">=1.8,<1.9.2 || >1.9.2"
+
+[package.extras]
+build = ["cython (>=0.29.33)"]
+develop = ["colorama", "cython (>=0.29.33)", "cython (>=3.0.10,<4)", "flake8", "isort", "joblib", "matplotlib (>=3)", "pytest (>=7.3.0,<8)", "pytest-cov", "pytest-randomly", "pytest-xdist", "pywinpty", "setuptools-scm[toml] (>=8.0,<9.0)"]
+docs = ["ipykernel", "jupyter-client", "matplotlib", "nbconvert", "nbformat", "numpydoc", "pandas-datareader", "sphinx"]
 
 [[package]]
 name = "tabulate"
@@ -3991,4 +4096,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9"
-content-hash = "a626d151f8bc70e15bdbd1501a24760dc1ead740c88966b53b18739777f6e373"
+content-hash = "0be7117e2b27f11e80192b21b0b30dc73359b78eac7bafd2d448b9173b0c71eb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ lxml = ">=5.1.0"
 htmltools = ">=0.5"
 jupyter = "^1.0.0"
 wrapt = "^1.16.0"
+statsmodels = "^0.14.2"
 
 [tool.poetry.group.dev.dependencies]
 black = "23.3.0"


### PR DESCRIPTION
<!-- Suggested PR Title: [feat/fix/refactor/perf/test/ci/docs/chore] brief description of the change -->
<!-- Please follow Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description

This PR aims to add demonstrations of how users can leverage Maidr to create double-layered scatterplots.

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Pull Request

## Description
This PR aims to include examples of how double-layered scatter plots can be created using maidr

## Related Issues
#85 

## Changes Made
This is a draft PR that has the new 2-layered scatterplot example. As the example is still in development phase, I have included the html generation as part of the example. Additionally, the `_inject_plot` method has been modified to accept a flag called `html`. If set to `True`, the `_inject_plot` method will return the bare html for the plot. The default value is `False` and if the flag is set to `False`, the iframe element containing the plot will be returned.

## Screenshots (if applicable)

## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [ ] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.

## Additional Notes

I am encountering the following issues by leveraging the current py-binder and upstream dependancies.

- In the maidr [example](https://xabilitylab.ischool.illinois.edu/maidr/galleries/scatterplot.html) shared on the issue, I am unable to use the &#8593; / &#8595; to switch between the line plot and scatterplot. 
- In the example I developed, the text related to the active component gets updated everytime I move from point to point on the scatterplot but the active components are not highlighted. 

I have this error showing up on DevTools when the html is validated:
<img width="1710" alt="scatter_2Layer" src="https://github.com/user-attachments/assets/ccb65a96-27e0-410f-a44d-52b9527693ce">

Whilst the secondary plot toggle seems to be an issue on the upstream repository, I would like to know if any additional changes should be done on the py-binder to activate highlighting of scatterplot components.
