### PR TITLE
ci(semantic-release): exclude non-conventional commits from `CHANGELOG`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ prerelease = false
 [tool.semantic_release.changelog]
 template_dir = "templates"
 changelog_file = "CHANGELOG.md"
-exclude_commit_patterns = []
+exclude_commit_patterns = ["^(?!feat: |fix: |docs: |perf: |refactor: |test: |build: ).*", "^chore: ", "^ci: ", "^style: "]
 
 [tool.semantic_release.changelog.environment]
 block_start_string = "{%"


### PR DESCRIPTION
This pull request updates the `exclude_commit_patterns` in the `pyproject.toml` file. The previous commits that don't match the conventional commits prefixes and internal changes that do not necessarily affect end-user interactions, such as `chore`, `ci`, and `style`, are excluded from our CHANGELOG and GitHub release note moving forward. This is not a direct fix, but after this change, it ensures that only relevant commits are included in the release changelog as a fair stopgap solution.

Closes #99