### PR TITLE
fix: address dynamic resizing of iframes on ipython

### DIFF
--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -189,7 +189,34 @@ class Maidr:
             tags.script(maidr),
         )
 
+        def generate_iframe_script(unique_id: str) -> str:
+            resizing_script = f"""
+                function resizeIframe() {{
+                    var iframe = document.getElementById('{unique_id}');
+                    if (iframe && iframe.contentWindow && iframe.contentWindow.document) {{
+                        var iframeDocument = iframe.contentWindow.document;
+                        var brailleContainer = iframeDocument.getElementById('braille-div');
+                        var height = iframeDocument.body.scrollHeight;
+                        if (brailleContainer && brailleContainer === iframeDocument.activeElement) {{
+                            height *= 1.35;  # Increase height by 35% if braille-container is in focus
+                        }}
+                        iframe.style.height = (height + 150) + 'px';
+                        iframe.style.width = iframeDocument.body.scrollWidth + 'px';
+                    }}
+                }}
+                var iframe = document.getElementById('{unique_id}');
+                iframe.onload = function() {{
+                    resizeIframe();
+                    iframe.contentWindow.addEventListener('resize', resizeIframe);
+                    iframe.contentWindow.document.addEventListener('focusin', resizeIframe);
+                    iframe.contentWindow.document.addEventListener('focusout', resizeIframe);
+                }};
+            """
+            return resizing_script
+
         unique_id = "iframe_" + Maidr._unique_id()
+
+        resizing_script = generate_iframe_script(unique_id)
 
         # Embed the rendering into an iFrame for proper working of JS library.
         base_html = tags.iframe(
@@ -197,14 +224,10 @@ class Maidr:
             srcdoc=str(base_html.get_html_string()),
             width="100%",
             height="100%",
-            scrolling="auto",
-            style="background-color: #fff",
+            scrolling="no",
+            style="background-color: #fff; position: relative; border: none",
             frameBorder=0,
-            onload="""
-                this.style.height = this.contentWindow.document.body.scrollHeight +
-                100 + 'px';
-            """
-            + Environment.initialize_llm_secrets(unique_id),
+            onload=resizing_script,
         )
 
         return base_html

--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+varfrom __future__ import annotations
 
 import io
 import json
@@ -192,11 +192,11 @@ class Maidr:
         def generate_iframe_script(unique_id: str) -> str:
             resizing_script = f"""
                 function resizeIframe() {{
-                    var iframe = document.getElementById('{unique_id}');
+                    let iframe = document.getElementById('{unique_id}');
                     if (iframe && iframe.contentWindow && iframe.contentWindow.document) {{
-                        var iframeDocument = iframe.contentWindow.document;
-                        var brailleContainer = iframeDocument.getElementById('braille-div');
-                        var height = iframeDocument.body.scrollHeight;
+                        let iframeDocument = iframe.contentWindow.document;
+                        let brailleContainer = iframeDocument.getElementById('braille-div');
+                        let height = iframeDocument.body.scrollHeight;
                         if (brailleContainer && brailleContainer === iframeDocument.activeElement) {{
                             height *= 1.35;  # Increase height by 35% if braille-container is in focus
                         }}
@@ -204,7 +204,7 @@ class Maidr:
                         iframe.style.width = iframeDocument.body.scrollWidth + 'px';
                     }}
                 }}
-                var iframe = document.getElementById('{unique_id}');
+                let iframe = document.getElementById('{unique_id}');
                 iframe.onload = function() {{
                     resizeIframe();
                     iframe.contentWindow.addEventListener('resize', resizeIframe);


### PR DESCRIPTION
<!-- Suggested PR Title: [feat/fix/refactor/perf/test/ci/docs/chore] brief description of the change -->
<!-- Please follow Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description

This PR includes changes for removing overflow on iframes and resizing them according to content of the plot.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

# Pull Request

## Description
This PR introduces JavaScript based changes to the generated iframe. We strictly remove overflow and scrolling for the plot that is maidr active and attach event listeners to find out the onFocus element. The major overflow happens when braille is activated. To address that, we have attached an onfocus event listener to the `braille-div` container and decide if we need to expand size of the iframe to accommodate for the additional space at the top.

This PR includes all changes made by @dakshpokar in his recent draft PR along with the Shiny specific changes I have made.


## Checklist
<!-- Please select all applicable options. -->
<!-- To select your options, please put an 'x' in the all boxes that apply. -->

- [X] I have read the [Contributor Guidelines](../CONTRIBUTING.md).
- [X] I have performed a self-review of my own code and ensured it follows the project's coding standards.
- [X] I have tested the changes locally following `ManualTestingProcess.md`, and all tests related to this pull request pass.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if applicable.
- [ ] I have added appropriate unit tests, if applicable.
