### PR TITLE
fix: address iframe resizing issue in jupyter notebooks

### DIFF
--- a/maidr/core/maidr.py
+++ b/maidr/core/maidr.py
@@ -193,24 +193,36 @@ class Maidr:
             resizing_script = f"""
                 function resizeIframe() {{
                     let iframe = document.getElementById('{unique_id}');
+
                     if (iframe && iframe.contentWindow && iframe.contentWindow.document) {{
                         let iframeDocument = iframe.contentWindow.document;
-                        let brailleContainer = iframeDocument.getElementById('braille-div');
+                        let brailleContainer = iframeDocument.getElementById('braille-input');
+
+                        iframe.style.height = 'auto';
+
                         let height = iframeDocument.body.scrollHeight;
                         if (brailleContainer && brailleContainer === iframeDocument.activeElement) {{
-                            height *= 1.35;  # Increase height by 35% if braille-container is in focus
+                            height += 100;
+                        }}else{{
+                            height += 50
                         }}
-                        iframe.style.height = (height + 150) + 'px';
+
+                        iframe.style.height = (height) + 'px';
                         iframe.style.width = iframeDocument.body.scrollWidth + 'px';
                     }}
                 }}
                 let iframe = document.getElementById('{unique_id}');
+                resizeIframe();
                 iframe.onload = function() {{
                     resizeIframe();
                     iframe.contentWindow.addEventListener('resize', resizeIframe);
-                    iframe.contentWindow.document.addEventListener('focusin', resizeIframe);
-                    iframe.contentWindow.document.addEventListener('focusout', resizeIframe);
                 }};
+                iframe.contentWindow.document.addEventListener('focusin', () => {{
+                    resizeIframe();
+                }});
+                iframe.contentWindow.document.addEventListener('focusout', () => {{
+                    resizeIframe();
+                }});
             """
             return resizing_script
 


### PR DESCRIPTION
<!-- Suggested PR Title: [feat/fix/refactor/perf/test/ci/docs/chore] brief description of the change -->
<!-- Please follow Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/ -->

## Description
This PR includes changes for removing overflow on iframes and resizing them according to content of the plot.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

# Pull Request

## Description
<!-- Provide a brief description of the changes made in this pull request. -->
This PR enhances iframe resizing behavior to dynamically adjust height and width based on content size and user interaction. Specifically, the height is recalculated with additional space (100px) when the braille-input field is focused, and 50px otherwise. This ensures the iframe is not clipped during braille mode. The script also adds event listeners for focusin, focusout, and resize events to trigger appropriate resizing as needed, which were added by @krishnanand5.